### PR TITLE
Add comprehensive Markdown documentation for core codebase.

### DIFF
--- a/documentation/adaptgraph.c.md
+++ b/documentation/adaptgraph.c.md
@@ -1,0 +1,70 @@
+# programs/adaptgraph.c
+
+## Overview
+
+This file contains functions designed to simulate graph adaptation, primarily for testing ParMETIS's adaptive repartitioning routines (`ParMETIS_V3_AdaptiveRepart`). The functions modify vertex weights or edge weights of a distributed graph to simulate changes in computational load or communication patterns that might occur in a dynamic application.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`AdaptGraph(graph_t *graph, idx_t afactor, MPI_Comm comm)`**:
+    *   Adapts the input `graph` by modifying its vertex weights.
+    *   `afactor`: A factor by which selected vertex weights are multiplied.
+    *   Randomly selects a number of local vertices (`nadapt`) using `FastRandomPermute`.
+    *   For these selected vertices, `vwgt[perm[i]]` is multiplied by `afactor`.
+    *   If `graph->adjwgt` is `NULL`, it allocates and initializes it to 1. (The commented-out section suggests an idea to also adapt edge weights based on new vertex weights, but it's not active).
+    *   Prints initial load imbalance statistics after adaptation.
+*   **`AdaptGraph2(graph_t *graph, idx_t afactor, MPI_Comm comm)`**:
+    *   Another version of graph adaptation.
+    *   With a small probability (2 out of `npes` PEs, or if `RandomInRange(npes+1) < 2`), it multiplies *all* local vertex weights on the selected PE by `afactor`. This creates a more significant, localized imbalance.
+    *   The commented-out section for adapting edge weights based on vertex weights is present here as well.
+    *   Prints initial load imbalance statistics.
+*   **`Mc_AdaptGraph(graph_t *graph, idx_t *part, idx_t ncon, idx_t nparts, MPI_Comm comm)`**:
+    *   Adapts a multi-constraint graph based on an existing partition `part`.
+    *   PE 0 generates random new target weights (`pwgts`) for each partition and each constraint.
+    *   These target weights are broadcast to all PEs.
+    *   Each vertex `i` then gets its `vwgt[i*ncon+h]` set to `pwgts[part[i]*ncon+h]`. This means all vertices in the same partition `p` get assigned the new target weight for partition `p` for each constraint. This simulates a scenario where the ideal load per vertex changes based on its current partition.
+
+## Important Variables/Constants
+
+*   **`graph->vwgt`**: Vertex weights, directly modified by these functions.
+*   **`graph->adjwgt`**: Edge weights, potentially initialized if NULL.
+*   **`afactor`**: The multiplication factor for adapting vertex weights.
+*   **`part` (in `Mc_AdaptGraph`)**: The existing partition of the graph.
+
+## Usage Examples
+
+```c
+// These functions are intended for testing ParMETIS.
+// A typical test scenario (e.g., in testadpt.c or similar):
+//
+// // 1. Read or generate a graph
+// ParallelReadGraph(&graph, filename, comm);
+//
+// // 2. Partition it initially
+// ParMETIS_V3_PartKway(..., &graph, ..., part_initial, ...);
+//
+// // 3. Adapt the graph to simulate dynamic changes
+// AdaptGraph(&graph, adaptation_factor, comm); // or AdaptGraph2 / Mc_AdaptGraph
+//
+// // 4. Call adaptive repartitioning
+// ParMETIS_V3_AdaptiveRepart(..., &graph, ..., part_adapted, ...);
+//
+// // 5. Analyze the quality of part_adapted
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Likely includes `parmetislib.h` and other common headers for ParMETIS executables/test programs. Provides `graph_t` and MPI wrappers.
+    *   `parmetislib.h` (indirectly): For `graph_t` structure, `idx_t` type, `gkMPI_*` wrappers, `ismalloc`, `imalloc`, `FastRandomPermute`, `RandomInRange`, `isum`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for `MPI_Comm_size`, `MPI_Comm_rank`, `MPI_Allreduce`, `MPI_Bcast`.
+    *   Standard C library: `stdlib.h` (for `srand`, `rand` via `RandomInRange`), `stdio.h` (for `printf`), `math.h` (for `pow` in commented sections).
+*   **Other Interactions**:
+    *   These functions directly modify the input `graph_t` structure, particularly its `vwgt` array.
+    *   They are designed to create imbalances or changes in the graph that adaptive repartitioning algorithms should then try to resolve.
+    *   The randomness ensures varied test conditions.
+
+```

--- a/documentation/akwayfm.c.md
+++ b/documentation/akwayfm.c.md
@@ -1,0 +1,106 @@
+# libparmetis/akwayfm.c
+
+## Overview
+
+This file implements the adaptive k-way refinement algorithm for parallel graph partitioning. Its primary role within the ParMETIS library is to improve the quality of an existing k-way partition by iteratively moving vertices between partitions to reduce edge cut while maintaining load balance. The "adaptive" nature likely refers to how it adjusts its strategy based on the current state of the partition, possibly by focusing on specific types of vertices or regions.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`KWayAdaptiveRefine(ctrl_t *ctrl, graph_t *graph, idx_t npasses)`**:
+    *   This is the main function in this file. It performs k-way partition refinement.
+    *   `ctrl`: A control structure containing global parameters like the number of processing elements (PEs), current PE ID, number of partitions, MPI communicator, and various tuning parameters (e.g., `ipc_factor`, `redist_factor`, debug levels).
+    *   `graph`: A graph structure containing local graph information (number of vertices/edges, adjacency lists, vertex weights, current partition assignments (`where` array), partition weights, etc.) and information about its distribution across PEs.
+    *   `npasses`: The maximum number of refinement passes to perform.
+    *   The function iterates multiple passes, and in each pass:
+        1.  It potentially permutes the order of processing partitions or vertices.
+        2.  It checks for load imbalance.
+        3.  It iterates through local vertices (in two sub-passes, potentially prioritizing "dirty" vertices or based on a `ProperSide` macro).
+        4.  For each border vertex, it evaluates potential moves to neighboring partitions based on a gain function (considering inter-processor communication (IPC) gain and redistribution gain) and load balance constraints (`badmaxpwgt`).
+        5.  If a beneficial move is found, vertex partition assignment (`tmp_where`) and local/global partition weights (`lnpwgts`, `gnpwgts`) are provisionally updated. Vertex degree information (`ckrinfo`) is also updated.
+        6.  After an initial pass of proposing moves, it performs a global reduction (`gkMPI_Allreduce`) to get proposed global partition weights (`pgnpwgts`).
+        7.  It calculates an `overfill` factor to determine if any proposed moves violate balance constraints excessively.
+        8.  If overweight, it iterates through the moved vertices again, potentially reverting some moves that contribute most to imbalance or have low gain, updating weights and degree information accordingly.
+        9.  Commits the final set of moves for the current sub-pass by updating the primary `where` array.
+        10. Identifies vertices whose external degree information needs to be updated locally (`update` array) or on other PEs (`supdate` array).
+        11. Communicates changed interface data (`CommChangedInterfaceData`) and lists of vertices needing updates to neighboring PEs using MPI (`gkMPI_Irecv`, `gkMPI_Isend`, `gkMPI_Waitall`).
+        12. Updates the external degree information (`ckrinfo`, `oldEDs`) for local and received remote vertices.
+        13. Updates the global partition weights (`gnpwgts`) and the total cut (`graph->mincut`).
+        14. The process stops if the cut does not improve or `npasses` are completed.
+
+### Macros
+
+*   **`ProperSide(c, from, other)`**:
+    *   A macro likely used to determine if a move from partition `from` to partition `other` is favorable in the current sub-pass `c`. It seems to divide partitions into two conceptual sides based on a permutation `pperm` and `c` (0 or 1) determines which direction of moves are currently being considered.
+
+## Important Variables/Constants
+
+*   **Graph Structure & Partitioning Data**:
+    *   `graph->nvtxs`, `graph->nedges`: Number of local vertices and edges.
+    *   `graph->vtxdist`: Distribution of vertices across PEs.
+    *   `graph->xadj`, `graph->adjncy`, `graph->adjwgt`: Local graph structure (CSR format).
+    *   `graph->where`: Array storing the partition assignment for each local and ghost vertex.
+    *   `graph->lnpwgts`, `graph->gnpwgts`: Local and global partition weights for each constraint.
+    *   `graph->ncon`: Number of constraints per vertex.
+    *   `graph->nvwgt`: Weights of vertices for each constraint.
+    *   `graph->vsize`: Size of the vertex (used for redistribution gain).
+    *   `graph->ckrinfo`: Array of `ckrinfo_t` structs, storing refinement information for each vertex (internal degree `id`, external degree `ed`, neighbor partition info `inbr`, `nnbrs`).
+    *   `graph->mincut`, `graph->lmincut`: Global and local edge cut.
+    *   `graph->home`: Array indicating the original PE of a vertex (used in uncoupled refinement).
+*   **Control & MPI Data**:
+    *   `ctrl->npes`, `ctrl->mype`: Total number of PEs and current PE's ID.
+    *   `ctrl->nparts`: Total number of partitions.
+    *   `ctrl->comm`: MPI communicator.
+    *   `ctrl->ubvec`: Target upper bound for partition weights (balance constraint).
+    *   `ctrl->tpwgts`: Target partition weights.
+    *   `ctrl->ipc_factor`, `ctrl->redist_factor`: Factors controlling the importance of edge cut reduction vs. load balance/redistribution.
+    *   `graph->nnbrs`, `graph->peind`, `graph->recvptr`, `graph->sendptr`: Data for MPI communication setup (neighboring PEs, send/receive buffer pointers).
+*   **Temporary & Algorithm State Variables**:
+    *   `npasses`: Number of refinement passes.
+    *   `tmp_where`: Temporary array for storing proposed partition assignments during a pass.
+    *   `moved`: Array to store indices of vertices moved in a pass.
+    *   `perm`, `pperm`: Permutation arrays for randomizing vertex and partition processing order.
+    *   `update`, `supdate`, `rupdate`: Arrays to manage lists of vertices whose states (e.g., degrees) need updating locally or remotely.
+    *   `htable`: Hash table to quickly check if a vertex is already marked for update.
+    *   `oldEDs`: Stores external degrees of vertices before an inner refinement iteration to track changes to `lmincut`.
+    *   `badmaxpwgt`: Computed maximum allowed weight for each partition based on `ubvec` and `tpwgts`.
+    *   `movewgts`: Accumulates the sum of weights of vertices moved to/from partitions in a pass.
+    *   `ognpwgts`: Stores global partition weights at the beginning of a sub-pass.
+    *   `pgnpwgts`: Stores proposed global partition weights after a round of moves.
+    *   `overfill`: Array to quantify how much proposed moves violate balance constraints.
+    *   `swchanges`, `rwchanges`: Buffers for sending/receiving information about interface vertex changes.
+*   **Constants (Implicit)**:
+    *   `SMALLFLOAT`: A small floating-point value used for comparisons, likely defined in `parmetislib.h` or a related header.
+
+## Usage Examples
+
+```
+N/A
+```
+This function is an internal component of the ParMETIS library and is typically called as part of a larger partitioning or repartitioning process (e.g., by functions like `ParMETIS_V3_AdaptiveRepart`). It's not meant to be used directly by end-users in standalone code.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: This header file is directly included. It provides definitions for core data structures (`ctrl_t`, `graph_t`, `ckrinfo_t`, `cnbr_t`, `ikv_t`), type definitions (`idx_t`, `real_t`), macros (e.g., `IFSET`, `DBG_TIME`, `WCOREPUSH`/`POP`, `PASSERT`, `INC_DEC`, `gk_SWAP`, `gk_max`, `rabs`), MPI wrapper function prototypes (`gkMPI_*`), and likely prototypes for various utility and helper functions used within `KWayAdaptiveRefine` such as:
+        *   `RandomPermute`, `FastRandomPermute`: For permuting arrays.
+        *   `ComputeParallelBalance`: To check load balance.
+        *   `ravg`: To compute average of real values.
+        *   `IsHBalanceBetterTT`, `IsHBalanceBetterFT`: To compare balance improvements.
+        *   `cnbrpoolGetNext`: To get memory from a pool for neighbor info.
+        *   `CommChangedInterfaceData`: For communicating interface changes.
+        *   `GlobalSESum`: For summing values across PEs.
+        *   `isorti`: For sorting integer arrays.
+        *   `rprintf`: For parallel printing (rank 0).
+        *   Memory management (`rwspacemalloc`, `iwspacemalloc`, `ikvwspacemalloc`, `iset`, `icopy`, `rcopy`, `rset`).
+        *   Timers (`starttimer`, `stoptimer`).
+    *   Other C files in ParMETIS: The function calls various helper and MPI communication wrapper functions that are implemented in other `.c` files within the `libparmetis` directory (e.g., functions related to communication, graph data structure manipulation, memory management, utility functions).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used extensively for parallel communication, as indicated by functions like `gkMPI_Allreduce`, `gkMPI_Bcast`, `gkMPI_Irecv`, `gkMPI_Isend`, `gkMPI_Waitall`, `gkMPI_Get_count`, and the use of `MPI_SUM`.
+*   **Other Interactions**:
+    *   The function directly modifies the `graph_t` structure passed to it, particularly `graph->where` (partition assignments), `graph->lnpwgts` and `graph->gnpwgts` (partition weights), `graph->ckrinfo` (refinement information), and `graph->mincut` (edge cut).
+    *   It reads control parameters and MPI settings from the `ctrl_t` structure.
+    *   The algorithm's behavior is influenced by the initial state of the graph partition and the various parameters set in `ctrl_t`.
+
+```

--- a/documentation/ametis.c.md
+++ b/documentation/ametis.c.md
@@ -1,0 +1,145 @@
+# libparmetis/ametis.c
+
+## Overview
+
+This file serves as the entry point for ParMETIS's parallel adaptive repartitioning capabilities. It implements a multilevel algorithm that aims to improve an existing partition or create a new one by utilizing diffusive repartitioning techniques. The core idea is to iteratively move data (vertices) across processors to minimize edge cut while maintaining or improving load balance, often involving coarsening the graph, partitioning the coarser graph, and then projecting the partition back and refining it. This is particularly useful for applications where the computational load or data distribution changes dynamically.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_V3_AdaptiveRepart(idx_t *vtxdist, idx_t *xadj, idx_t *adjncy, idx_t *vwgt, idx_t *vsize, idx_t *adjwgt, idx_t *wgtflag, idx_t *numflag, idx_t *ncon, idx_t *nparts, real_t *tpwgts, real_t *ubvec, real_t *ipc2redist, idx_t *options, idx_t *edgecut, idx_t *part, MPI_Comm *comm)`**:
+    *   This is the primary public API function in this file for performing adaptive repartitioning.
+    *   **Parameters**:
+        *   `vtxdist`, `xadj`, `adjncy`: Distributed graph structure (CSR format).
+        *   `vwgt`: Vertex weights (if `wgtflag` indicates).
+        *   `vsize`: Vertex sizes (used for redistribution).
+        *   `adjwgt`: Edge weights (if `wgtflag` indicates).
+        *   `wgtflag`: Flags indicating presence of vertex/edge weights.
+        *   `numflag`: Flag indicating 0-based or 1-based indexing.
+        *   `ncon`: Number of constraints on vertex weights.
+        *   `nparts`: Desired number of partitions.
+        *   `tpwgts`: Target partition weights for each constraint.
+        *   `ubvec`: Load imbalance tolerance for each constraint.
+        *   `ipc2redist`: A real value, likely `ipc_factor`, that balances inter-processor communication (edge cut) reduction against data redistribution.
+        *   `options`: Array for various ParMETIS options (e.g., debug level, specific strategy flags).
+        *   `edgecut` (output): Stores the resulting edge cut.
+        *   `part` (input/output): Initially contains the existing partition (if any) and stores the new partition.
+        *   `comm`: MPI communicator.
+    *   **Functionality**:
+        1.  Performs input validation (`CheckInputsAdaptiveRepart`).
+        2.  Initializes memory management (`gk_malloc_init`).
+        3.  Sets up a control structure (`ctrl_t`) with options and parameters (`SetupCtrl`).
+        4.  Handles the trivial case of `nparts == 1`.
+        5.  Adjusts numbering if `numflag` indicates 1-based indexing (`ChangeNumbering`).
+        6.  Sets up the graph structure (`SetupGraph`), including local vertex data and initial partition information (`graph->home`).
+        7.  Allocates workspace memory (`AllocateWSpace`).
+        8.  Sets partitioning parameters like `ipc_factor` and `CoarsenTo`.
+        9.  Calls the core recursive partitioning function `Adaptive_Partition`.
+        10. Remaps the graph data based on the new partition (`ParallelReMapGraph`).
+        11. Copies the resulting partition to the output `part` array and sets `edgecut`.
+        12. Prints timing and post-partitioning info if debug flags are set.
+        13. Frees graph structures and control structures.
+        14. Reverts numbering if `numflag` was 1.
+        15. Checks for memory leaks.
+        16. Returns `METIS_OK` on success or `METIS_ERROR` on failure.
+
+*   **`Adaptive_Partition(ctrl_t *ctrl, graph_t *graph)`**:
+    *   This is an internal, recursive function that implements the multilevel adaptive partitioning strategy.
+    *   **Parameters**:
+        *   `ctrl`: The control structure.
+        *   `graph`: The current graph structure (could be a coarsened version of the original).
+    *   **Functionality (Recursive Multilevel Approach)**:
+        1.  Sets up communication structures for the current graph level (`CommSetup`).
+        2.  Calculates a `redist_factor` based on global edge weight and vertex size sums, influencing balance between cut and redistribution.
+        3.  **Base Case**: If the graph is small enough (compared to `ctrl->CoarsenTo`) or significantly smaller than the next finer graph:
+            *   Allocates refinement workspace.
+            *   Initializes `graph->where` from `graph->home`.
+            *   Balances the partition if it's significantly imbalanced (`Balance_Partition`), especially if not in a pure refinement mode.
+            *   If it's the original graph (no finer graph exists), it may perform initial balancing and then adaptive refinement (`KWayBalance`, `KWayAdaptiveRefine`).
+        4.  **Recursive Step**: If the graph is large enough:
+            *   Coarsens the graph: Selects matching strategy (`Match_Local` for coupled, `Match_Global` for uncoupled) to create `graph->coarser`.
+            *   Recursively calls `Adaptive_Partition` on `graph->coarser`.
+            *   Projects the partition from `graph->coarser` back to the current `graph` (`ProjectPartition`).
+            *   Computes partition parameters for the current level.
+            *   If multiple constraints exist and the graph is not too coarse, it may perform balancing (`KWayBalance`) if imbalance is detected.
+            *   Performs adaptive k-way refinement (`KWayAdaptiveRefine`) to improve the projected partition.
+        5.  Debug progress information is printed if enabled.
+
+## Important Variables/Constants
+
+*   **Input/Output Parameters (for `ParMETIS_V3_AdaptiveRepart`)**:
+    *   `vtxdist`, `xadj`, `adjncy`: Define the distributed graph.
+    *   `vwgt`, `vsize`, `adjwgt`: Define vertex weights, sizes, and edge weights.
+    *   `ncon`, `nparts`: Define number of constraints and target partitions.
+    *   `tpwgts`, `ubvec`: Define target partition weights and imbalance tolerance.
+    *   `ipc2redist`: Factor balancing cut minimization and data redistribution.
+    *   `options`: Control various behaviors.
+    *   `edgecut`, `part`: Output variables for cut and partition.
+    *   `comm`: MPI communicator.
+*   **Core Internal Structures**:
+    *   `ctrl_t *ctrl`: Control structure holding global settings, MPI info, options.
+    *   `graph_t *graph`: Graph structure holding local graph data, partition info, and pointers to coarser/finer graphs in the multilevel hierarchy.
+*   **Key Control Parameters (within `ctrl_t` or derived)**:
+    *   `ctrl->ipc_factor`: Importance of inter-processor communication (edge cut).
+    *   `ctrl->redist_factor`: Importance of data redistribution/balance.
+    *   `ctrl->CoarsenTo`: Target size for the coarsest graph.
+    *   `ctrl->ps_relation`: `PARMETIS_PSR_COUPLED` or `PARMETIS_PSR_UNCOUPLED`, affecting matching strategy.
+*   **Constants**:
+    *   `PARMETIS_OP_AMETIS`: Operation type identifier for adaptive METIS.
+    *   `NGR_PASSES`: Default number of passes for certain refinement operations (e.g., `KWayAdaptiveRefine`).
+    *   `COARSEN_FRACTION`: Ratio determining when to stop coarsening based on size reduction.
+    *   `REFINE_PARTITION`: A mode for `ctrl->partType`, possibly indicating a refinement-only approach.
+
+## Usage Examples
+
+```
+N/A for direct usage of Adaptive_Partition.
+```
+The function `ParMETIS_V3_AdaptiveRepart` is an API function intended to be called by user applications linking against the ParMETIS library. A typical usage would involve:
+1.  Setting up the distributed graph data (`vtxdist`, `xadj`, `adjncy`, weights, etc.) on each MPI process.
+2.  Defining partitioning parameters (`nparts`, `tpwgts`, `ubvec`, `options`, etc.).
+3.  Calling `ParMETIS_V3_AdaptiveRepart` with these parameters.
+4.  Using the output `part` array (new partition assignments) and `edgecut` value.
+
+Example call signature:
+```c
+// Assume all parameters are initialized appropriately
+idx_t edgecut;
+MPI_Comm comm = MPI_COMM_WORLD; // Or a specific application communicator
+
+int ret = ParMETIS_V3_AdaptiveRepart(vtxdist, xadj, adjncy,
+                                     vwgt, vsize, adjwgt,
+                                     &wgtflag, &numflag, &ncon, &nparts,
+                                     tpwgts, ubvec, &ipc2redist_factor,
+                                     options, &edgecut, part, &comm);
+
+if (ret == METIS_OK) {
+    // Use the new 'part' array and 'edgecut'
+}
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Directly included. Provides definitions for `ctrl_t`, `graph_t`, types (`idx_t`, `real_t`), constants, macros, and prototypes for numerous functions used in this file, including:
+        *   Input checking: `CheckInputsAdaptiveRepart`
+        *   Setup: `SetupCtrl`, `SetupGraph`, `CommSetup`
+        *   Memory management: `gk_malloc_init`, `gk_GetCurMemoryUsed`, `gk_malloc_cleanup`, `AllocateWSpace`, `AllocateRefinementWorkSpace`, `rwspacemalloc`, `ismalloc`, `FreeCtrl`, `FreeInitialGraphAndRemap`, `WCOREPUSH`/`POP`
+        *   Numbering & Remapping: `ChangeNumbering`, `ParallelReMapGraph`
+        *   Core Partitioning Steps: `Match_Local`, `Match_Global` (coarsening), `ProjectPartition`, `Balance_Partition`, `KWayBalance` (balancing), `KWayAdaptiveRefine` (refinement, implemented in `akwayfm.c`).
+        *   Parameter computation: `ComputePartitionParams`, `ComputeParallelBalance`
+        *   Utilities: `icopy`, `isum`, `ravg`, `GlobalSESum`, `GlobalSEMin`, `GlobalSEMax`, `GlobalSEMinComm`
+        *   Debugging & Timing: `IFSET`, `DBG_TIME`, `DBG_PROGRESS`, `DBG_INFO`, `PrintTimingInfo`, `PrintPostPartInfo`, `rprintf`, `STARTTIMER`/`STOPTIMER`
+        *   Graph I/O (conditional): `graph_WriteToDisk`, `graph_ReadFromDisk`
+    *   `akwayfm.c`: The `KWayAdaptiveRefine` function, a crucial part of the refinement phase, is implemented in this file.
+    *   Other `.c` files in `libparmetis/`: Various helper functions for graph manipulation, coarsening strategies, balancing algorithms, communication wrappers, etc., are implemented across different source files.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Essential for parallelism. Used for setting up communicators (`MPI_Comm`), and for various global reduction/communication operations (often via `gkMPI_` wrappers defined in ParMETIS).
+*   **Other Interactions**:
+    *   The function `ParMETIS_V3_AdaptiveRepart` modifies the user-provided `part` array to store the new partition and `edgecut` to store the resulting cut value.
+    *   The behavior of the algorithms is heavily influenced by the `options` array and other numerical parameters (`nparts`, `tpwgts`, `ubvec`, `ipc2redist`).
+    *   The multilevel approach involves creating and destroying temporary graph structures (`graph->coarser`, `graph->finer`) during execution.
+    *   Memory usage is tracked using `gk_GetCurMemoryUsed` to detect potential leaks.
+
+```

--- a/documentation/balancemylink.c.md
+++ b/documentation/balancemylink.c.md
@@ -1,0 +1,94 @@
+# libparmetis/balancemylink.c
+
+## Overview
+
+This file implements a specialized edge-based Fiduccia-Mattheyses (FM) refinement algorithm. The primary function, `BalanceMyLink`, aims to balance the "flow" (representing workload or data imbalance) between two specific, adjacent partitions, denoted as `me` and `you`. It iteratively moves vertices between these two partitions to reduce the specified flow imbalance while trying to minimize edge cut and considering data redistribution costs. This routine is likely used as a low-level component within more complex load balancing or adaptive refinement schemes in ParMETIS.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`BalanceMyLink(ctrl_t *ctrl, graph_t *graph, idx_t *home, idx_t me, idx_t you, real_t *flows, real_t maxdiff, real_t *diff_cost, real_t *diff_lbavg, real_t avgvwgt)`**:
+    *   This is the sole function in this file. It performs a 2-way FM-based refinement/balancing pass between partitions `me` and `you`.
+    *   **Parameters**:
+        *   `ctrl`: Control structure containing global parameters like `ipc_factor` and `redist_factor`.
+        *   `graph`: Graph structure containing local graph information (vertices, edges, weights, current partition in `graph->where`).
+        *   `home`: An array indicating the original "home" partition for each vertex. This is used to calculate redistribution costs/gains.
+        *   `me`, `you`: The identifiers of the two partitions between which balancing is performed. Vertices considered must belong to either `me` or `you`.
+        *   `flows`: An array representing the current imbalance (or "flow" of weights/load) for each constraint between partition `me` and `you`. Positive values might mean `me` needs to send to `you`, negative means `you` needs to send to `me`. The function aims to reduce these flow values.
+        *   `maxdiff`: A threshold related to the desired level of balance or maximum allowed difference.
+        *   `diff_cost` (output): The total cost (considering edge cut and redistribution) after the balancing attempt.
+        *   `diff_lbavg` (output): The average load imbalance between `me` and `you` after balancing.
+        *   `avgvwgt`: Average vertex weight, potentially used in heuristics for selecting queues or vertices.
+    *   **Functionality**:
+        1.  Initializes local data structures, including workspace for vertex degrees, mappings, and priority queues.
+        2.  Calculates initial total partition weights (`pwgts`) for `me` and `you`, and then target partition weights (`tpwgts`) based on the initial weights and the input `flows`.
+        3.  Categorizes vertices by a hash of their weights (`Mc_HashVwgts`) into multiple priority queues (`queues`). Separate sets of queues are maintained for vertices in partition `me` and partition `you`.
+        4.  Computes initial internal (`id`) and external (`ed`) degrees for each vertex with respect to partitions `me` and `you`.
+        5.  Performs a number of FM passes (`N_MOC_BAL_PASSES`):
+            *   Resets and populates priority queues. For each vertex, calculates a gain based on `ipc_factor` (reduction in edge cut) and `redist_factor` (cost/benefit of moving from/to its `home` partition).
+            *   Tracks the `bestflow` achieved (minimum absolute flow value).
+            *   Iteratively selects the most promising queue and vertex to move using `Mc_DynamicSelectQueue`, which considers the current `flows` and `avgvwgt`.
+            *   Moves the selected vertex (`vtx`) from its current partition (`from`) to the other (`to`). Updates `where[vtx]`.
+            *   Updates the `flows` array based on the moved vertex's weights.
+            *   If the new `flows` represent a better balance (`ftmp < bestflow`), resets a list of `changes`. Otherwise, adds the moved vertex to `changes`.
+            *   Updates the `id` and `ed` of the moved vertex and its neighbors, and updates their gains in the priority queues.
+            *   After iterating (e.g., up to `nvtxs/2` potential moves), it rolls back moves stored in `changes` to revert to the state that achieved `bestflow`.
+            *   If no moves were made in a pass, it breaks early.
+        6.  After all passes, calculates the final load balance (`diff_lbavg`) between `me` and `you` based on the final `where` assignments and `tpwgts`.
+        7.  Calculates the final cost (`diff_cost`) based on the resulting edge cut between `me` and `you` and the total `vsize` of vertices not in their `home` partition.
+        8.  Frees allocated workspace, including priority queues.
+        9.  Returns the total number of successful swaps (`nswaps`).
+
+## Important Variables/Constants
+
+*   **Input/Output Parameters**:
+    *   `me`, `you`: The two partitions involved in balancing.
+    *   `flows`: Array (input/output) representing weight imbalance for `ncon` constraints; the function aims to reduce these values.
+    *   `home`: Array indicating the "ideal" or original partition for each vertex.
+    *   `diff_cost`, `diff_lbavg`: Output values for cost and load balance.
+*   **Graph Data (from `graph_t`)**:
+    *   `nvtxs`, `ncon`, `xadj`, `adjncy`, `adjwgt`, `nvwgt`, `vsize`, `where`.
+*   **Control Parameters (from `ctrl_t`)**:
+    *   `ipc_factor`: Weight for inter-processor communication (edge cut) in gain calculations.
+    *   `redist_factor`: Weight for data redistribution cost in gain calculations.
+*   **FM Algorithm Data Structures**:
+    *   `queues (rpq_t **)`: Array of pointers to priority queues, used to select vertices with high gain.
+    *   `hval`: Array storing a hash value for each vertex (based on its `nvwgt`), used for queue assignment.
+    *   `id`, `ed`: Arrays storing internal and external weighted degrees of vertices with respect to partitions `me` and `you`.
+    *   `myqueue`: Array indicating if a vertex is currently in a queue and for which partition.
+    *   `map`, `rmap`: Mapping arrays for efficient access to vertices within the queues.
+    *   `changes`: Array to log vertex moves, enabling rollback to the best state.
+*   **Partition Weight Tracking**:
+    *   `pwgts`: Initial weights of partitions `me` and `you`.
+    *   `tpwgts`: Target weights for partitions `me` and `you`, derived from `pwgts` and `flows`.
+*   **Constants**:
+    *   `N_MOC_BAL_PASSES`: Defines the number of passes the FM algorithm will perform.
+    *   `PE 0`: Defined but unused in the logic.
+
+## Usage Examples
+
+```
+N/A
+```
+This function is a specialized internal routine within ParMETIS. It is not intended for direct use by end-users. It's likely called by higher-level functions that manage overall load balancing or adaptive partitioning, which might identify pairs of partitions (`me`, `you`) and specific `flows` between them that need adjustment.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Directly included. This header provides:
+        *   Core data structures: `ctrl_t`, `graph_t`.
+        *   Priority Queue (`rpq_t`) API: `rpqCreate`, `rpqInsert`, `rpqGetTop`, `rpqUpdate`, `rpqReset`, `rpqDestroy`.
+        *   Memory management: `iwspacemalloc`, `rwspacemalloc`, `wspacemalloc`, `rset`, `iset`, `WCOREPUSH`/`WCOREPOP`.
+        *   Helper functions: `Mc_HashVwgts` (for categorizing vertices by weight for queueing), `Mc_DynamicSelectQueue` (for selecting which queue/vertex to process next), `ravg` (for averaging).
+        *   Macros: `ASSERT`, `gk_SWAP`, `INC_DEC`.
+    *   It is expected to be called by other ParMETIS functions that orchestrate larger-scale balancing or refinement, which would determine the `me`, `you`, and `flows` parameters.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: `gkMPI_Comm_rank(MPI_COMM_WORLD, &mype)` is called at the beginning, but the returned `mype` is not subsequently used in the core logic. The function primarily operates on data assumed to be locally available for the specified `me` and `you` partitions, implying that the calling context handles the necessary data distribution or setup.
+*   **Other Interactions**:
+    *   The function modifies the `graph->where` array for vertices that are moved between partitions `me` and `you`.
+    *   The input `flows` array is modified in place to reflect the changes due to vertex moves.
+    *   The `diff_cost` and `diff_lbavg` variables are updated to provide feedback to the caller on the outcome of the balancing attempt.
+    *   The `home` array is read-only and influences gain calculations related to redistribution.
+
+```

--- a/documentation/comm.c.md
+++ b/documentation/comm.c.md
@@ -1,0 +1,67 @@
+# libparmetis/comm.c
+
+## Overview
+
+This file provides high-level communication functions essential for parallel graph operations within ParMETIS. It includes routines to set up communication structures for distributed graphs, exchange data for interface (ghost) vertices, and perform global reductions (like sum, min, max) across MPI processes. These functions abstract the underlying MPI calls and manage the necessary data structures for efficient inter-process communication.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`CommSetup(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Sets up the communication infrastructure for a distributed graph.
+    *   Determines which processors own vertices adjacent to local vertices (i.e., identifies interface/ghost vertices).
+    *   Localizes the numbering of adjacency lists: local vertices are numbered `0` to `nvtxs-1`, and remote (ghost) vertices are numbered `nvtxs` to `nvtxs+nrecv-1`.
+    *   Populates graph fields related to communication: `graph->nrecv` (number of ghost vertices), `graph->recvind` (global indices of ghost vertices), `graph->nnbrs` (number of neighbor PEs), `graph->peind` (IDs of neighbor PEs), `graph->recvptr` (CSR-like pointer for `recvind` per PE).
+    *   Determines send information: `graph->nsend` (number of local vertices to be sent), `graph->sendind` (local indices of vertices to be sent), `graph->sendptr` (CSR-like pointer for `sendind` per PE).
+    *   Creates `graph->pexadj`, `graph->peadjncy`, `graph->peadjloc` for sparse boundary exchanges.
+    *   Creates `graph->imap` to map local/ghost indices back to global vertex indices.
+*   **`CommUpdateNnbrs(ctrl_t *ctrl, idx_t nnbrs)`**:
+    *   Updates (reallocates if necessary) MPI request and status arrays within the `ctrl` structure if the number of communicating neighbors (`nnbrs`) increases beyond the currently allocated capacity (`ctrl->ncommpes`).
+*   **`CommInterfaceData(ctrl_t *ctrl, graph_t *graph, idx_t *data, idx_t *recvvector)`**:
+    *   Exchanges data for interface/ghost vertices. Each PE sends its local `data` values for vertices listed in `graph->sendind` to appropriate neighbors.
+    *   Received data is stored in `recvvector`, corresponding to the order in `graph->recvind`.
+    *   Uses non-blocking MPI sends (`gkMPI_Isend`) and receives (`gkMPI_Irecv`) followed by `gkMPI_Waitall`.
+*   **`CommChangedInterfaceData(ctrl_t *ctrl, graph_t *graph, idx_t nchanged, idx_t *changed, idx_t *data, ikv_t *sendpairs, ikv_t *recvpairs)`**:
+    *   A more optimized version of `CommInterfaceData` for exchanging data of only a subset of interface vertices that have changed.
+    *   `nchanged` and `changed` specify the local vertices whose `data` has changed.
+    *   Uses `ikv_t` (key-value pairs) to send data, where key is the remote index (offset) and value is the data.
+    *   `peadjloc` (from `CommSetup`) is used to map local vertex changes to the correct indices in neighbor PEs' receive buffers.
+*   **`GlobalSEMax(ctrl_t *ctrl, idx_t value)`**: Computes the global maximum of an `idx_t` value across all PEs in `ctrl->comm`.
+*   **`GlobalSEMaxComm(MPI_Comm comm, idx_t value)`**: Computes global maximum on a specific communicator.
+*   **`GlobalSEMin(ctrl_t *ctrl, idx_t value)`**: Computes the global minimum of an `idx_t` value.
+*   **`GlobalSEMinComm(MPI_Comm comm, idx_t value)`**: Computes global minimum on a specific communicator.
+*   **`GlobalSESum(ctrl_t *ctrl, idx_t value)`**: Computes the global sum of an `idx_t` value.
+*   **`GlobalSESumComm(MPI_Comm comm, idx_t value)`**: Computes global sum on a specific communicator.
+*   **`GlobalSEMaxFloat(ctrl_t *ctrl, real_t value)`**: Computes the global maximum of a `real_t` value.
+*   **`GlobalSEMinFloat(ctrl_t *ctrl, real_t value)`**: Computes the global minimum of a `real_t` value.
+*   **`GlobalSESumFloat(ctrl_t *ctrl, real_t value)`**: Computes the global sum of a `real_t` value.
+
+## Important Variables/Constants
+
+*   **`graph->vtxdist`**: Array defining the distribution of global vertices to PEs.
+*   **`graph->adjncy`**: Adjacency list; modified by `CommSetup` to use local/ghost numbering.
+*   **`graph->lperm`**: Permutation array used internally by `CommSetup` to distinguish local-only vertices.
+*   **`graph->nlocal`**: Number of vertices with only local adjacencies.
+*   **`graph->imap`**: Maps local vertex indices (0 to nvtxs-1) and ghost vertex indices (nvtxs to nvtxs+nrecv-1) to their global vertex IDs.
+*   **`ctrl->sreq`, `ctrl->rreq`, `ctrl->statuses`**: Arrays to manage MPI request handles and statuses for non-blocking communication.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS communication routines, typically called by other higher-level parallel algorithms (e.g., partitioning, refinement, matrix-vector multiplication). `CommSetup` is fundamental for initializing how a distributed graph communicates. `CommInterfaceData` and `CommChangedInterfaceData` are used to synchronize data associated with ghost vertices. Global reduction functions are used for collective decision-making or data aggregation.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides definitions for `ctrl_t`, `graph_t`, `ikv_t`, type `idx_t`, `real_t`, MPI wrappers (`gkMPI_*`), timer macros (`STARTTIMER`, `STOPTIMER`), memory allocation (`imalloc`, `ikvwspacemalloc`, `iwspacemalloc`, `ismalloc`, `icopy`, `iincset`), CSR utilities (`MAKECSR`, `SHIFTCSR`), sorting (`ikvsorti`), and assertion macros (`PASSERT`, `PASSERTP`).
+    *   Other ParMETIS modules: This file is foundational for almost all parallel operations in ParMETIS. Any module that operates on a distributed graph and needs to exchange boundary information or perform global reductions will rely on these communication primitives.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for all inter-processor communication (e.g., `MPI_Alltoall`, `MPI_Irecv`, `MPI_Isend`, `MPI_Waitall`, `MPI_Allreduce`). The `gkMPI_` functions are wrappers around standard MPI calls.
+*   **Other Interactions**:
+    *   `CommSetup` significantly modifies the `graph_t` structure by populating its communication-related fields and renumbering parts of `graph->adjncy`.
+    *   The global reduction functions depend on the `ctrl->comm` (or a user-provided `MPI_Comm`) for collective operations.
+
+```

--- a/documentation/csrmatch.c.md
+++ b/documentation/csrmatch.c.md
@@ -1,0 +1,56 @@
+# libparmetis/csrmatch.c
+
+## Overview
+
+This file contains code for computing matchings in a graph represented in Compressed Sparse Row (CSR) format. The specific matching algorithm implemented is the Sorted Heavy Edge Matching (SHEM) heuristic. This is often used in multilevel graph partitioning during the coarsening phase to select pairs of vertices to collapse together.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`CSR_Match_SHEM(matrix_t *matrix, idx_t *match, idx_t *mlist, idx_t *skip, idx_t ncon)`**:
+    *   Computes a matching in the graph/matrix using the Sorted Heavy-Edge Matching (SHEM) heuristic.
+    *   **Parameters**:
+        *   `matrix`: A `matrix_t` structure representing the graph (or matrix). It's expected to have `nrows`, `rowptr` (CSR row pointers), `colind` (CSR column indices), and `transfer` (analogous to edge weights, possibly representing flow or connectivity strength across `ncon` constraints).
+        *   `match`: An array of size `nrows` that will store the matching information. `match[i] = j` means vertex `i` is matched with vertex `j`. Unmatched vertices are marked `UNMATCHED`.
+        *   `mlist`: An array that stores the pairs of matched vertices. For each match `(i, j)`, it stores `max(i,j)` then `min(i,j)`.
+        *   `skip`: An array indicating edges that should be ignored (skipped) during matching. `skip[j_idx] == 0` means the edge can be considered.
+        *   `ncon`: The number of constraints or components associated with edge weights (from `matrix->transfer`). The matching considers the maximum absolute value across these constraints as the edge weight.
+    *   **Functionality**:
+        1.  Initializes all vertices as `UNMATCHED`.
+        2.  Creates a list of `links` (edges), where each link's weight is the maximum absolute value of `transfer` over `ncon` constraints for that edge. Associates each link with its source vertex.
+        3.  Sorts the vertices based on the heaviest link incident to them in descending order (`rkvsortd(nrows, links)` on `links[i].key`).
+        4.  Iterates through the sorted vertices:
+            *   If a vertex `i` is `UNMATCHED`:
+                *   It searches for an `UNMATCHED` neighbor `edge` connected by a non-skipped edge.
+                *   Among eligible neighbors, it selects the one that forms the heaviest edge with `i` (based on `matrix->transfer` values).
+                *   If such a neighbor `maxidx` is found (and `maxidx != i`), it matches `i` with `maxidx` (`match[i] = maxidx`, `match[maxidx] = i`) and records the pair in `mlist`.
+        5.  Frees the temporary `links` array.
+
+## Important Variables/Constants
+
+*   **`matrix->rowptr`, `matrix->colind`**: CSR representation of the graph structure.
+*   **`matrix->transfer`**: Array storing edge weights, potentially multi-constraint. The matching heuristic uses the max absolute value over `ncon` as the effective edge weight.
+*   **`match[i] = UNMATCHED`**: Indicates vertex `i` is not yet matched.
+*   **`skip[j_idx]`**: If non-zero, the edge at index `j_idx` in the CSR structure is ignored.
+*   **`links (rkv_t *)`**: Temporary array of key-value pairs used to sort vertices by their heaviest incident edge weight. `key` stores the weight, `val` stores the vertex index.
+
+## Usage Examples
+
+```
+N/A
+```
+This function is an internal component of ParMETIS, typically used during the graph coarsening phase of multilevel partitioning algorithms. It's not intended for direct use by end-users. A higher-level coarsening function would call `CSR_Match_SHEM` to find a matching, which then guides how vertices are merged to create a coarser graph.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides the `matrix_t` structure definition, `rkv_t` type, memory management (`rkvmalloc`, `gk_free`), sorting (`rkvsortd`), mathematical utilities (`fabs`, `gk_max`, `gk_min`), and the `UNMATCHED` constant.
+    *   This function is a key part of the coarsening process. The output `match` array is used by other functions to construct the next coarser graph.
+*   **External Libraries**:
+    *   None explicitly mentioned beyond standard C libraries implicitly used by helpers (e.g., `math.h` for `fabs`).
+*   **Other Interactions**:
+    *   The quality of the matching produced by `CSR_Match_SHEM` can significantly impact the overall quality of the partitioning produced by ParMETIS.
+    *   The `skip` array allows other parts of the algorithm to prevent certain edges from being part of the matching.
+
+```

--- a/documentation/ctrl.c.md
+++ b/documentation/ctrl.c.md
@@ -1,0 +1,84 @@
+# libparmetis/ctrl.c
+
+## Overview
+
+This file is responsible for managing the `ctrl_t` control structure in ParMETIS. The `ctrl_t` structure holds various parameters, options, and state information that govern the behavior of the ParMETIS algorithms. Functions in this file handle the setup (allocation and initialization) and teardown (deallocation) of this critical structure.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`SetupCtrl(pmoptype_et optype, idx_t *options, idx_t ncon, idx_t nparts, real_t *tpwgts, real_t *ubvec, MPI_Comm comm)`**:
+    *   Allocates and initializes a `ctrl_t` structure.
+    *   **Parameters**:
+        *   `optype`: The type of ParMETIS operation being performed (e.g., `PARMETIS_OP_KMETIS`, `PARMETIS_OP_AMETIS`).
+        *   `options`: An array of options provided by the user. If `NULL` or `options[0] == 0`, default options are used.
+        *   `ncon`: Number of balance constraints.
+        *   `nparts`: Number of target partitions.
+        *   `tpwgts`: Array of target partition weights for each constraint.
+        *   `ubvec`: Array of imbalance tolerance for each constraint.
+        *   `comm`: The MPI communicator to be used.
+    *   **Functionality**:
+        *   Duplicates the input MPI communicator (`ctrl->gcomm`, `ctrl->comm`).
+        *   Sets `mype` (MPI rank) and `npes` (MPI size).
+        *   Parses the `options` array or sets default values for:
+            *   `partType`: Type of partitioning (STATIC, ADAPTIVE, REFINE).
+            *   `ps_relation`: Coarsening relationship (COUPLED, UNCOUPLED), especially for adaptive/refine modes.
+            *   `dbglvl`: Debug level, also used to set boolean flags like `dropedges`, `twohop`, `fast`, `ondisk`.
+            *   `seed`: Random number seed.
+        *   Initializes other common control parameters: `optype`, `ncon`, `nparts`, `redist_factor`, `redist_base`.
+        *   Allocates and initializes `ctrl->tpwgts` (target partition weights) and `ctrl->ubvec` (imbalance tolerances).
+        *   Initializes timers (`InitTimers`).
+        *   Seeds the random number generator (`srand`).
+*   **`SetupCtrl_invtvwgts(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Computes the inverse of the total vertex weights for each constraint and stores them in `ctrl->invtvwgts`.
+    *   This is often used to normalize partition weights or calculate load balance ratios.
+    *   Requires `graph->vwgt` (vertex weights) and `graph->ncon`.
+*   **`FreeCtrl(ctrl_t **r_ctrl)`**:
+    *   Deallocates all memory associated with the `ctrl_t` structure.
+    *   Frees workspace allocated via `WSpace` calls.
+    *   Frees the duplicated MPI communicator if `ctrl->free_comm` is set.
+    *   Frees arrays like `invtvwgts`, `ubvec`, `tpwgts`, and MPI request arrays.
+    *   Sets the input pointer `*r_ctrl` to `NULL`.
+
+## Important Variables/Constants
+
+*   **`ctrl_t` (struct)**: This is the central structure managed by this file. Key members initialized include:
+    *   `comm`, `gcomm`: MPI communicators.
+    *   `mype`, `npes`: MPI rank and size.
+    *   `optype`: Type of ParMETIS operation.
+    *   `partType`: Partitioning type (STATIC, ADAPTIVE, REFINE).
+    *   `ps_relation`: Coarsening strategy (COUPLED, UNCOUPLED).
+    *   `dbglvl`, `seed`: Debug level and random seed.
+    *   `ncon`, `nparts`: Number of constraints and partitions.
+    *   `tpwgts`: Target partition weights.
+    *   `ubvec`: Imbalance tolerance vector.
+    *   `invtvwgts`: Inverse of total vertex weights per constraint.
+    *   `ipc_factor`, `redist_factor`, `redist_base`: Factors for balancing cut vs. redistribution.
+    *   Arrays for MPI requests: `sreq`, `rreq`, `statuses`.
+*   **`PMV3_OPTION_DBGLVL`, `PMV3_OPTION_SEED`, `PMV3_OPTION_PSR`**: Indices for accessing specific options in the user-provided `options` array.
+*   **`UNBALANCE_FRACTION`**: Default value for imbalance if not specified.
+*   **`GLOBAL_DBGLVL`, `GLOBAL_SEED`**: Default debug level and seed if `options` is not provided.
+
+## Usage Examples
+
+```
+N/A
+```
+These functions are fundamental to the initialization and finalization phases of any ParMETIS routine. `SetupCtrl` is one of the first functions called to prepare the environment, and `FreeCtrl` is called at the end to release resources. End-users of the ParMETIS library indirectly cause these functions to be called when they invoke a ParMETIS API function (e.g., `ParMETIS_V3_PartKway`).
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `pmoptype_et`, `ctrl_t`, `graph_t` definitions, constants (e.g., `PARMETIS_OP_*`, `PARMETIS_PSR_*`, `UNBALANCE_FRACTION`), MPI wrappers (`gkMPI_*`), memory management (`gk_malloc`, `rmalloc`, `rsmalloc`, `rcopy`, `gk_free`), timer functions (`InitTimers`), and workspace management (`FreeWSpace`). It also includes `defs.h` which defines many default constants.
+    *   `comm.c`: `GlobalSEMax` is used to synchronize the seed if needed.
+    *   `graph.c`: `isum` (from `gklib.c` via `graph.c`'s includes) is used in `SetupCtrl_invtvwgts`.
+    *   The `ctrl_t` structure created and managed here is passed to almost all other ParMETIS functions, controlling their behavior.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for `MPI_Comm_dup`, `MPI_Comm_rank`, `MPI_Comm_size`, `MPI_Comm_free`.
+    *   Standard C library: `memset`, `srand`, `getpid`.
+*   **Other Interactions**:
+    *   The `options` array passed by the user directly influences the settings within the `ctrl_t` structure.
+    *   The `dbglvl` set in `ctrl_t` controls debugging output throughout ParMETIS.
+
+```

--- a/documentation/debug.c.md
+++ b/documentation/debug.c.md
@@ -1,0 +1,63 @@
+# libparmetis/debug.c
+
+## Overview
+
+This file contains various utility functions used for debugging purposes within the ParMETIS library. These functions facilitate the printing of distributed data structures like vectors and graphs, communication setup information, and other internal states in a synchronized manner across multiple MPI processes. They are primarily used during development and testing to verify the correctness of algorithms and data.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`PrintVector(ctrl_t *ctrl, idx_t n, idx_t first, idx_t *vec, char *title)`**:
+    *   Prints an array (`vec`) of `n` elements from each processor. `first` is an offset for global indexing in the printout. Output is synchronized by PE.
+*   **`PrintVector2(ctrl_t *ctrl, idx_t n, idx_t first, idx_t *vec, char *title)`**:
+    *   Similar to `PrintVector`, but seems to interpret `vec` elements with a `KEEP_BIT`, printing a primary value and a secondary value derived from the bit.
+*   **`PrintPairs(ctrl_t *ctrl, idx_t n, ikv_t *pairs, char *title)`**:
+    *   Prints an array of `n` `ikv_t` (key-value) pairs from each processor. Output is synchronized.
+*   **`PrintGraph(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Prints the local portion of a distributed graph (`graph`) from each processor, including vertex weights, adjacency lists, and edge weights. Output is synchronized.
+*   **`PrintGraph2(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Similar to `PrintGraph`, but also includes partitioning information (`where[i]`) and refinement data (`ckrinfo[i].id`, `ckrinfo[i].ed`) for each vertex.
+*   **`PrintSetUpInfo(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Prints detailed information about the communication setup for a distributed graph, including send/receive counts and indices for each neighboring processor. Output is synchronized.
+*   **`PrintTransferedGraphs(ctrl_t *ctrl, idx_t nnbrs, idx_t *peind, idx_t *slens, idx_t *rlens, idx_t *sgraph, idx_t *rgraph)`**:
+    *   Prints information about graphs (or subgraphs) that are being transferred between processors, detailing vertex counts, edge counts, and adjacency information for sent and received graph portions.
+*   **`WriteMetisGraph(idx_t nvtxs, idx_t *xadj, idx_t *adjncy, idx_t *vwgt, idx_t *adjwgt)`**:
+    *   Writes a graph (assumed to be local, from a single processor's perspective) to a file named "test.graph" in the standard METIS graph file format. This is useful for extracting a local graph component for analysis with serial METIS tools.
+
+## Important Variables/Constants
+
+*   **`ctrl->mype`**: MPI rank of the current processor, used for coordinating print order.
+*   **`ctrl->npes`**: Total number of MPI processors.
+*   **`ctrl->comm`**: MPI communicator used for `gkMPI_Barrier` to synchronize output.
+*   **`graph->vtxdist`**: Vertex distribution array, used to get `firstvtx` for global numbering in printouts.
+*   **`KEEP_BIT`**: A bitmask (likely `(1<<30)` or similar, from context of its usage with `idx_t`) used in `PrintVector2` to encode two pieces of information in a single `idx_t`.
+
+## Usage Examples
+
+```c
+// Example of how PrintVector might be used internally:
+// if (ctrl->dbglvl & DBG_SOME_FLAG) {
+//   PrintVector(ctrl, graph->nvtxs, graph->vtxdist[ctrl->mype], graph->where, "Partition Vector");
+// }
+
+// To write the local graph of PE 0 to "test.graph":
+// if (ctrl->mype == 0) {
+//   WriteMetisGraph(graph->nvtxs, graph->xadj, graph->adjncy, graph->vwgt, graph->adjwgt);
+// }
+```
+These functions are typically called within `IFSET(ctrl->dbglvl, DBG_XYZ, ...)` blocks, meaning they are active only when specific debug flags are enabled in the `ctrl->dbglvl` parameter.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `graph_t`, `ikv_t` definitions, `idx_t` type, `KEEP_BIT` constant (likely via included `defs.h` or `struct.h`), and MPI wrappers (`gkMPI_Barrier`).
+    *   These functions are not typically depended upon by core algorithmic modules but are rather called from them for debugging.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: `gkMPI_Barrier` is used extensively to ensure that output from different processors is printed in an orderly fashion rather than interleaved.
+    *   Standard C I/O: `fprintf`, `printf`, `fflush`, `fopen`, `fclose`.
+*   **Other Interactions**:
+    *   The output of these functions is directed to `stdout`.
+    *   `WriteMetisGraph` creates a file named "test.graph" in the current working directory.
+
+```

--- a/documentation/defs.h.md
+++ b/documentation/defs.h.md
@@ -1,0 +1,83 @@
+# libparmetis/defs.h
+
+## Overview
+
+This header file contains a collection of global constant definitions used throughout the ParMETIS library. These constants define default behaviors, algorithm parameters, limits, specific modes of operation, and debug levels. Centralizing these definitions allows for easier configuration and tuning of the library's internal workings.
+
+## Key Components
+
+### Functions/Classes/Modules/Macros/Structs
+
+This file primarily consists of `#define` directives for constants.
+
+### Important Variables/Constants
+
+A wide range of constants are defined, categorized as follows:
+
+*   **Default Global Settings**:
+    *   `GLOBAL_DBGLVL`: Default debug level if not specified by the user.
+    *   `GLOBAL_SEED`: Default random number seed if not specified.
+*   **Algorithm Parameters & Thresholds**:
+    *   `NUM_INIT_MSECTIONS`: Number of initial multi-sections.
+    *   `MC_FLOW_BALANCE_THRESHOLD`: Threshold for flow balance in multi-constraint context.
+    *   `MOC_GD_GRANULARITY_FACTOR`: Granularity factor for multi-constraint gradient descent.
+    *   `RIP_SPLIT_FACTOR`: Factor for Recursive Inertial Partitioning splits.
+    *   `MAX_NPARTS_MULTIPLIER`: Multiplier for maximum number of parts.
+    *   `REDIST_WGT`: A weight factor, possibly for redistribution cost.
+    *   `MAXNVWGT_FACTOR`: Factor for maximum node weight.
+    *   `N_MOC_REDO_PASSES`, `N_MOC_GR_PASSES`, `NREMAP_PASSES`, `N_MOC_GD_PASSES`, `N_MOC_BAL_PASSES`, `NMATCH_PASSES`: Number of passes for various internal algorithms (Multi-constraint operations, Remapping, Matching).
+    *   `NGD_PASSES`: Number of gradient descent passes.
+    *   `NGR_PASSES`: Number of greedy refinement passes.
+    *   `NIPARTS`: Number of random initial partitions.
+    *   `NLGR_PASSES`: Number of greedy refinement passes during initial partitioning.
+    *   `SMALLFLOAT`: A small floating-point value for comparisons.
+    *   `COARSEN_FRACTION`, `COARSEN_FRACTION2`: Node reduction ratios between successive coarsening levels.
+    *   `UNBALANCE_FRACTION`, `ORDER_UNBALANCE_FRACTION`: Default imbalance tolerance for partitioning and ordering.
+    *   `MAXVWGT_FACTOR`: Maximum vertex weight factor, possibly used in load balancing constraints.
+*   **Operation Modes & Types**:
+    *   `STATIC_PARTITION`, `ORDER_PARTITION`, `ADAPTIVE_PARTITION`, `REFINE_PARTITION`: Identifiers for different types of partitioning operations.
+    *   `PMV3_OPTION_DBGLVL`, `PMV3_OPTION_SEED`, `PMV3_OPTION_IPART`, `PMV3_OPTION_PSR`: Indices for accessing options in the `options` array for ParMETIS V3 API.
+    *   `XYZ_XCOORD`, `XYZ_SPFILL`: Options possibly related to geometric partitioning or sparse fill.
+    *   `ISEP_EDGE`, `ISEP_NODE`: Types of initial vertex separator algorithms.
+*   **Special Values & Markers**:
+    *   `UNMATCHED`, `MAYBE_MATCHED`, `TOO_HEAVY`: Markers used in matching algorithms.
+    *   `HTABLE_EMPTY`: Marker for an empty slot in a hash table.
+    *   `LTERM`: List terminator for `GKfree` variadic function (`(void **) 0`).
+*   **Limits & Constraints**:
+    *   `MAX_NCON_FOR_DIFFUSION`: Maximum number of constraints for which diffusion is attempted.
+    *   `SMALLGRAPH`: Threshold defining a "small" graph, possibly triggering different algorithmic paths.
+*   **Debug Levels (Bitmasks)**:
+    *   `DBG_TIME` (`PARMETIS_DBGLVL_TIME`): Enables timing information.
+    *   `DBG_INFO` (`PARMETIS_DBGLVL_INFO`): Enables general informational output.
+    *   `DBG_PROGRESS` (`PARMETIS_DBGLVL_PROGRESS`): Enables progress output during execution.
+    *   `DBG_REFINEINFO` (`PARMETIS_DBGLVL_REFINEINFO`): Enables detailed refinement information.
+    *   `DBG_MATCHINFO` (`PARMETIS_DBGLVL_MATCHINFO`): Enables detailed matching information.
+    *   `DBG_RMOVEINFO` (`PARMETIS_DBGLVL_RMOVEINFO`): Enables information about refinement moves.
+    *   `DBG_REMAP` (`PARMETIS_DBGLVL_REMAP`): Enables remapping information.
+    *   (Note: `PARMETIS_DBGLVL_*` constants are themselves defined in `parmetis.h`, which is typically included before `defs.h` via `parmetislib.h`)
+
+## Usage Examples
+
+```c
+// Example of how a constant from defs.h might be used:
+// if (graph->nvtxs < SMALLGRAPH) {
+//   // Use a simpler algorithm for small graphs
+// }
+//
+// for (pass=0; pass<NGR_PASSES; pass++) {
+//   // Perform a greedy refinement pass
+// }
+```
+These constants are used directly in C code throughout ParMETIS to control behavior, loop counts, array sizes, and conditional compilation or execution paths.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   This file is typically included via `parmetislib.h`, which itself includes `parmetis.h`. Some constants defined here (like `DBG_*`) are aliases to `PARMETIS_DBGLVL_*` constants defined in `parmetis.h`.
+    *   These constants are used by virtually all C files within the `libparmetis` directory to govern algorithmic choices, parameters, and debugging outputs.
+*   **External Libraries**:
+    *   None. This file only contains preprocessor definitions.
+*   **Other Interactions**:
+    *   Changing values in this file can significantly alter the behavior, performance, and output quality of ParMETIS algorithms. It's a central place for tuning and configuring default settings.
+
+```

--- a/documentation/dglpart.c.md
+++ b/documentation/dglpart.c.md
@@ -1,0 +1,86 @@
+# programs/dglpart.c
+
+## Overview
+
+This program is a specialized tool for partitioning graphs for use with DistDGL (Distributed Deep Graph Library). It reads graph data in a specific format (likely edges and node features/labels from separate files), partitions the graph using ParMETIS, physically redistributes the graph data (including metadata) according to this partition, and then writes out the partitioned subgraphs in a format suitable for DistDGL. A key aspect is its handling of node and edge metadata which needs to be moved along with the graph structure. It also employs a cyclic mapping for distributing vertices initially to balance memory usage during the reading and initial processing phases.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`main(int argc, char *argv[])`**:
+    *   Entry point. Parses command-line arguments (input file stem, number of partitions per PE).
+    *   Calls `DistDGL_GPart`.
+*   **`DistDGL_GPart(char *fstem, idx_t nparts_per_pe, MPI_Comm comm)`**:
+    *   Orchestrates the overall process:
+        1.  Reads the graph data using `DistDGL_ReadGraph`.
+        2.  Reports peak memory usage.
+        3.  Partitions the graph using `ParMETIS_V3_PartKway`.
+        4.  Moves the graph (including metadata) according to the partition using `DistDGL_MoveGraph`.
+        5.  Writes the partitioned subgraphs to disk using `DistDGL_WriteGraphs`.
+        6.  Reports peak memory usage again.
+*   **`DistDGL_ReadGraph(char *fstem, MPI_Comm comm)`**:
+    *   Reads graph data from multiple files: `<fstem>_stats.txt`, `<fstem>_edges.txt`, `<fstem>_nodes.txt`.
+    *   **Stats file**: Provides global number of vertices, edges, and number of constraints (node features).
+    *   **Edges file**: Each line is `dest_id source_id <metadata_string>`. Edges are read in chunks by PE 0 and distributed to other PEs based on a cyclic mapping of source/destination IDs to balance load during reading.
+    *   **Nodes file**: Each line is `<constraint_values> <metadata_string>`. Node data is also read in chunks and distributed.
+    *   Handles potentially large metadata strings associated with nodes and edges. Metadata is temporarily stored to disk by `DistDGL_MoveGraph` before being re-read by `DistDGL_WriteGraphs` (or, in this read function, saved to disk after reading before being moved).
+    *   Constructs a local `graph_t` object on each PE. The global graph is implicitly represented by these distributed pieces.
+*   **`DistDGL_MoveGraph(graph_t *ograph, idx_t *part, idx_t nparts_per_pe, MPI_Comm comm)`**:
+    *   Redistributes the `ograph` (original graph) based on the computed `part` vector to create `mgraph` (moved graph).
+    *   Similar to the standard `MoveGraph` in ParMETIS, but with added complexity to handle node/edge metadata (`vmptr`, `emptr`, `vmdata`, `emdata`) and vertex types (`vtype`).
+    *   Calculates send/receive counts and displacements for graph structure and all associated metadata.
+    *   Uses `gkMPI_Alltoall` for count exchange and `gkMPI_Isend`/`gkMPI_Irecv`/`gkMPI_Waitall` for data exchange.
+*   **`DistDGL_WriteGraphs(char *fstem, graph_t *graph, idx_t nparts_per_pe, MPI_Comm comm)`**:
+    *   Writes the local subgraphs held by each PE to output files.
+    *   Each PE is responsible for `nparts_per_pe` partitions.
+    *   Before writing, it renumbers the local vertices within each partition to have contiguous IDs starting from 0 for that partition, and globally unique IDs across all partitions using `CommSetup` and `CommInterfaceData` on a temporarily created graph structure.
+    *   For each partition `p` assigned to the current PE, it creates:
+        *   `p<global_part_id>-<fstem>_nodes.txt`: Node ID (new local) and its metadata string.
+        *   `p<global_part_id>-<fstem>_edges.txt`: Source node ID (new local), Dest node ID (new local), and edge metadata string.
+*   **`DistDGL_CheckMGraph(ctrl_t *ctrl, graph_t *graph, idx_t nparts_per_pe)`**:
+    *   A debugging function to check the consistency of the moved graph, similar to `CheckMGraph` in `move.c`.
+*   **`i2kvsorti(size_t n, i2kv_t *base)` / `i2kvsortii(size_t n, i2kv_t *base)`**:
+    *   Sorting functions for `i2kv_t` structures (key1, key2, val). `i2kvsorti` sorts by key1, key2 (asc) then val (desc). `i2kvsortii` sorts by key1, key2, val (all asc).
+*   **`DistDGL_mapFromCyclic(idx_t u, idx_t npes, idx_t *vtxdist)` / `DistDGL_mapToCyclic(idx_t u, idx_t npes, idx_t *vtxdist)`**:
+    *   Helper functions for mapping global vertex ID `u` to/from a cyclic distribution target PE and local index. The cyclic distribution aims to balance memory when reading large graph files. `vtxdist` here is the standard ParMETIS vtxdist for the *target* cyclic distribution, not the final partition.
+
+### mvinfo_t (struct)
+*   A simple struct to hold counts of data to be moved: `nvtxs`, `nedges`, `nvmdata` (size of vertex metadata), `nemdata` (size of edge metadata).
+
+## Important Variables/Constants
+
+*   **`fstem`**: File stem for input and output graph files.
+*   **`nparts_per_pe`**: Number of graph partitions each processor will manage/output.
+*   **`CHUNKSIZE`**: Size of chunks for reading large edge/node files.
+*   `graph->vmptr`, `graph->emptr`, `graph->vmdata`, `graph->emdata`: Store pointers and actual string data for vertex and edge metadata.
+*   `graph->vtype`: Stores type information for each vertex.
+
+## Usage Examples
+
+```bash
+# Command-line execution:
+mpirun -np <num_procs> dglpart <graph_file_stem> <num_partitions_per_proc>
+
+# Example:
+mpirun -np 4 dglpart mygraph 2
+# This would partition 'mygraph' into 4*2=8 total partitions.
+# Each of the 4 PEs would write out 2 partition files.
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` and common headers.
+    *   `parmetislib.h` (indirectly): For `ctrl_t`, `graph_t`, ParMETIS API functions (`ParMETIS_V3_PartKway`), MPI wrappers, memory management, sorting utilities.
+    *   `io.c` (from `libparmetis`): Although this `dglpart.c` has its own I/O, it doesn't directly use `pio.c` from the library but rather implements custom file reading for the DistDGL format.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For all parallel operations.
+    *   Standard C library: For file I/O (`stdio.h`), string manipulation (`string.h`), memory allocation (`stdlib.h`).
+*   **Other Interactions**:
+    *   Reads input graph data (structure, node features/types, edge features) from text files with a specific naming convention based on `fstem`.
+    *   Outputs multiple files, one set per final partition, containing the subgraph structure and associated metadata.
+    *   The cyclic mapping during the read phase is a strategy to deal with potentially skewed distributions in the input files and improve load balance during initial data loading and distribution.
+    *   Metadata is temporarily written to disk (`emdata-<pid>-<mype>.bin`, `vmdata-<pid>-<mype>.bin`) by `DistDGL_ReadGraph` before being moved by `DistDGL_MoveGraph` and then presumably re-read by `DistDGL_WriteGraphs` to include in the final output files. This is a way to manage potentially large metadata that might not fit in memory if kept for all vertices/edges during all stages.
+
+```

--- a/documentation/diffutil.c.md
+++ b/documentation/diffutil.c.md
@@ -1,0 +1,72 @@
+# libparmetis/diffutil.c
+
+## Overview
+
+This file contains utility functions primarily supporting diffusion-based load balancing and adaptive refinement schemes within ParMETIS. This includes setting up a "connectivity graph" or matrix representing connections between partitions, computing statistics about vertex movements, calculating loads, and a Conjugate Gradient (CG) solver likely used for solving linear systems that arise in diffusion algorithms.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`SetUpConnectGraph(graph_t *graph, matrix_t *matrix, idx_t *workspace)`**:
+    *   Constructs a coarse-grained matrix (`matrix`) representing the connectivity between partitions based on the fine-grained `graph`.
+    *   The rows of the `matrix` correspond to partitions. `matrix->values[rowptr[ii]]` stores the number of external connections for partition `ii`, and `matrix->values[k] = -1.0` for off-diagonal entries `colind[k]` indicate a connection to another partition.
+    *   Uses a `workspace` for permutations and marking.
+*   **`Mc_ComputeMoveStatistics(ctrl_t *ctrl, graph_t *graph, idx_t *nmoved, idx_t *maxin, idx_t *maxout)`**:
+    *   Computes statistics about vertex movements for multi-constraint adaptive refinement.
+    *   Calculates:
+        *   `nmoved`: Total amount of vertex weight/size that moved from its original partition (`graph->home` or `ctrl->mype` for coupled mode).
+        *   `maxin`: Maximum total weight/size of vertices that moved into any single partition.
+        *   `maxout`: Maximum total weight/size of vertices that moved out of any single partition.
+    *   Uses MPI_Allreduce to get global sums.
+*   **`Mc_ComputeSerialTotalV(graph_t *graph, idx_t *home)`**:
+    *   Computes the total "volume" or weight of vertices that are not in their specified `home` partition in a serial graph context (or for the local portion of a distributed graph).
+    *   Uses `graph->vsize` if available, otherwise the first component of `graph->vwgt`.
+*   **`ComputeLoad(graph_t *graph, idx_t nparts, real_t *load, real_t *tpwgts, idx_t index)`**:
+    *   Computes the current load for each of `nparts` partitions for a specific constraint `index`.
+    *   The load is calculated as `actual_weight[p] - target_weight[p]`.
+    *   The sum of `actual_weight` is asserted to be close to 1.0 (implying normalized weights).
+*   **`ConjGrad2(matrix_t *A, real_t *b, real_t *x, real_t tol, real_t *workspace)`**:
+    *   Implements a Conjugate Gradient (CG) solver to find `x` in `Ax = b`.
+    *   `A` is a matrix (likely the connectivity matrix from `SetUpConnectGraph`).
+    *   `b` is the right-hand side vector (e.g., load imbalances).
+    *   `x` is the solution vector (e.g., desired flow).
+    *   `tol` is the error tolerance.
+    *   `workspace` is used for temporary vectors `p, r, q, z, M` (preconditioner).
+    *   The preconditioner `M` is the inverse of the diagonal of `A`.
+*   **`mvMult2(matrix_t *A, real_t *v, real_t *w)`**:
+    *   Performs a matrix-vector multiplication `w = A*v` for the `matrix_t` structure.
+*   **`ComputeTransferVector(idx_t ncon, matrix_t *matrix, real_t *solution, real_t *transfer, idx_t index)`**:
+    *   Based on a `solution` vector (likely from `ConjGrad2`, representing potentials or pressures), computes a `transfer` vector.
+    *   For each edge `(j, colind[k])` in the `matrix`, if `solution[j] > solution[colind[k]]`, then `transfer[k*ncon+index]` is set to their difference, otherwise 0. This quantifies potential flow along matrix edges.
+
+## Important Variables/Constants
+
+*   **`matrix_t`**: Structure representing a sparse matrix, typically the connectivity between partitions. Key members: `nrows`, `rowptr`, `colind`, `values`, `nnzs`.
+*   **`graph_t`**: Structure for the fine-grained graph. Key members used: `nvtxs`, `xadj`, `adjncy`, `where`, `vwgt`, `vsize`, `ncon`, `home`.
+*   **`ctrl_t`**: Control structure, used for `ps_relation`, `mype`, `nparts`, and MPI communicator.
+
+## Usage Examples
+
+```
+N/A
+```
+These functions are internal utilities for ParMETIS, primarily supporting diffusion-based load balancing algorithms.
+*   `SetUpConnectGraph` would be called to build a coarse representation of inter-partition connectivity.
+*   `ComputeLoad` would calculate imbalances.
+*   `ConjGrad2` would solve for corrective flows based on the connectivity and imbalances.
+*   `ComputeTransferVector` would translate the solution of the linear system into concrete transfer amounts along graph edges.
+*   `Mc_ComputeMoveStatistics` and `Mc_ComputeSerialTotalV` help in analyzing the results of partitioning or refinement.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `graph_t`, `matrix_t`, `ctrl_t` definitions, `idx_t`, `real_t` types, MPI wrappers (`gkMPI_Allreduce`), memory utilities (`iset`, `ismalloc`, `gk_free`), CSR utilities (`MAKECSR`), math utilities (`fabs`, `rsum`, `rnorm2`, `rdot`, `rcopy`, `raxpy`, `isum`, `imax`), and `ASSERT`.
+    *   These utilities are likely called by higher-level diffusion algorithms (e.g., `mdiffusion.c`) or adaptive refinement schedulers.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used in `Mc_ComputeMoveStatistics` for `gkMPI_Allreduce`.
+*   **Other Interactions**:
+    *   The functions operate on and modify data within `graph_t` and `matrix_t` structures.
+    *   The CG solver assumes a symmetric positive definite (or semi-definite) matrix, which is typical for diffusion problems.
+
+```

--- a/documentation/frename.c.md
+++ b/documentation/frename.c.md
@@ -1,0 +1,76 @@
+# libparmetis/frename.c
+
+## Overview
+
+This file provides Fortran wrapper interfaces for several ParMETIS C API functions. It addresses the common issue of name mangling differences between C and Fortran compilers by defining multiple versions of the function name (e.g., all uppercase, all lowercase, with trailing underscore, with double trailing underscore). Each wrapper function converts the Fortran MPI communicator (`MPI_Fint`) to a C MPI communicator (`MPI_Comm`) before calling the actual C ParMETIS function.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+The file primarily consists of a macro `FRENAME` and its instantiations for various ParMETIS API functions.
+
+*   **`FRENAME(name0, name1, name2, name3, name4, dargs, cargs)` (Macro)**:
+    *   A macro used to generate the Fortran wrapper functions.
+    *   `name0`: The actual C function name (e.g., `ParMETIS_V3_AdaptiveRepart`).
+    *   `name1` to `name4`: The variously mangled Fortran names (e.g., `PARMETIS_V3_ADAPTIVEREPART`, `parmetis_v3_adaptiverepart`, `parmetis_v3_adaptiverepart_`, `parmetis_v3_adaptiverepart__`).
+    *   `dargs`: The declaration of arguments for the wrapper functions, including `MPI_Fint *icomm`.
+    *   `cargs`: The arguments to be passed to the C function `name0`, with `*icomm` being converted to `comm` via `MPI_Comm_f2c`.
+
+The following ParMETIS V3 API functions are wrapped using this macro:
+*   **`ParMETIS_V3_AdaptiveRepart`**: For adaptive repartitioning.
+*   **`ParMETIS_V3_PartGeomKway`**: For geometric k-way partitioning using coordinates and graph structure.
+*   **`ParMETIS_V3_PartGeom`**: For geometric partitioning based only on coordinates.
+*   **`ParMETIS_V3_PartKway`**: For graph partitioning using k-way multilevel algorithm.
+*   **`ParMETIS_V3_Mesh2Dual`**: For converting a mesh to its dual graph.
+*   **`ParMETIS_V3_PartMeshKway`**: For partitioning a mesh.
+*   **`ParMETIS_V3_NodeND`**: For computing fill-reducing orderings of sparse matrices.
+*   **`ParMETIS_V3_RefineKway`**: For refining an existing k-way partition.
+
+Each instantiation of `FRENAME` creates four wrapper functions. For example, for `ParMETIS_V3_AdaptiveRepart`, it creates:
+*   `PARMETIS_V3_ADAPTIVEREPART(...)`
+*   `parmetis_v3_adaptiverepart(...)`
+*   `parmetis_v3_adaptiverepart_(...)`
+*   `parmetis_v3_adaptiverepart__(...)`
+
+All these wrappers internally call the C function `ParMETIS_V3_AdaptiveRepart` after converting the Fortran MPI communicator.
+
+## Important Variables/Constants
+
+*   **`MPI_Fint *icomm`**: Fortran MPI communicator handle passed to the wrapper.
+*   **`MPI_Comm comm`**: C MPI communicator handle, converted from `*icomm` using `MPI_Comm_f2c`.
+
+## Usage Examples
+
+```fortran
+! Example of how a Fortran program might call one of these wrappers
+! (assuming appropriate ParMETIS library linking and USE MPI)
+
+INTEGER(KIND=MPI_ADDRESS_KIND) :: vtxdist(npes+1)
+INTEGER(KIND=MPI_ADDRESS_KIND) :: xadj(nvtxs+1)
+INTEGER(KIND=MPI_ADDRESS_KIND) :: adjncy(nedges)
+! ... other parameters ...
+INTEGER :: part(nvtxs)
+INTEGER :: edgecut
+INTEGER :: options(PARMETIS_MAX_OPTIONS)
+INTEGER :: icomm_f ! Fortran MPI communicator
+! ... initialize parameters and icomm_f ...
+
+CALL parmetis_v3_partkway(vtxdist, xadj, adjncy, vwgt, adjwgt, &
+                         wgtflag, numflag, ncon, nparts, tpwgts, ubvec, &
+                         options, edgecut, part, icomm_f)
+```
+The user links against the ParMETIS library, and the Fortran linker picks the appropriately named symbol based on the compiler's convention.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides the prototypes for the actual C ParMETIS API functions (e.g., `ParMETIS_V3_AdaptiveRepart`).
+    *   The C functions defined elsewhere in the library (e.g., `ametis.c`, `ometis.c`, `kmetis.c`) are the ultimate targets of these wrappers.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Requires the MPI library for the `MPI_Comm_f2c` function to convert Fortran communicators to C communicators.
+*   **Other Interactions**:
+    *   This file is crucial for Fortran interoperability. Without it, Fortran programs would have a much harder time calling ParMETIS C functions due to name mangling and MPI communicator type differences.
+    *   The specific set of mangled names provided (uppercase, lowercase, single underscore, double underscore) covers common conventions for Fortran compilers on various systems.
+
+```

--- a/documentation/gklib.c.md
+++ b/documentation/gklib.c.md
@@ -1,0 +1,66 @@
+# libparmetis/gklib.c
+
+## Overview
+
+This file is an integration point for GKlib (George Karypis Library) utilities within ParMETIS. GKlib is a separate library containing a rich set of low-level routines for memory allocation, array operations (BLAS-like), sorting, random number generation, priority queues, and more. Instead of directly including GKlib source or linking against it as a separate entity, ParMETIS incorporates a customized, templated version of these utilities directly into its codebase. This file uses preprocessor macros (GK_MK*) defined in GKlib's template system to generate concrete implementations of these utilities for specific data types used in ParMETIS (like `idx_t`, `real_t`, `ikv_t`, `rkv_t`).
+
+## Key Components
+
+### Functions/Classes/Modules
+
+This file primarily consists of instantiations of GKlib macros that generate functions.
+
+*   **BLAS Routines**:
+    *   `GK_MKBLAS(i, idx_t, idx_t)`: Generates BLAS-like functions for `idx_t` arrays (e.g., `icopy`, `iset`, `isum`, `imax`, `imin`, `iaxpy`, `idot`, `iscale`, `inorm2`, `iargmax`, `iargmin`).
+    *   `GK_MKBLAS(r, real_t, real_t)`: Generates BLAS-like functions for `real_t` arrays (e.g., `rcopy`, `rset`, `rsum`, `rmax`, `rmin`, `raxpy`, `rdot`, `rscale`, `rnorm2`, `rargmax`, `rargmin`).
+*   **Memory Allocation Routines**:
+    *   `GK_MKALLOC(i, idx_t)`: Generates memory allocation/deallocation functions for `idx_t` (e.g., `imalloc`, `ismalloc`, `irealloc`, `iAllocMatrix`, `iFreeMatrix`, `iSetMatrix`).
+    *   `GK_MKALLOC(r, real_t)`: Generates memory allocation functions for `real_t` (e.g., `rmalloc`, `rsmalloc`, `rrealloc`).
+    *   `GK_MKALLOC(ikv, ikv_t)`: Generates memory allocation functions for `ikv_t` (key-value pairs with `idx_t`).
+    *   `GK_MKALLOC(rkv, rkv_t)`: Generates memory allocation functions for `rkv_t` (key-value pairs with `real_t` key, `idx_t` value).
+*   **Priority Queue Routines**:
+    *   `GK_MKPQUEUE(ipq, ipq_t, ikv_t, idx_t, idx_t, ikvmalloc, IDX_MAX, key_gt)`: Generates functions for managing priority queues (`ipq_t`) storing `ikv_t` items, ordered by `idx_t` keys. Examples: `ipqCreate`, `ipqInsert`, `ipqGetTop`, `ipqDelete`, `ipqUpdate`, `ipqDestroy`.
+    *   `GK_MKPQUEUE(rpq, rpq_t, rkv_t, real_t, idx_t, rkvmalloc, REAL_MAX, key_gt)`: Generates functions for priority queues (`rpq_t`) storing `rkv_t` items, ordered by `real_t` keys. Examples: `rpqCreate`, `rpqInsert`, `rpqGetTop`, etc.
+*   **Random Number Generation Routines**:
+    *   `GK_MKRANDOM(i, idx_t, idx_t)`: Generates random number functions for `idx_t` (e.g., `isrand`, `irand`, `irandArrayPermute`, `irandInRange`).
+*   **Utility Routines**:
+    *   `GK_MKARRAY2CSR(i, idx_t)`: Generates `iarray2csr` for converting an array representation to CSR format for `idx_t`.
+*   **Sorting Routines**:
+    *   Explicitly defined qsort-based functions (not using GK_MKQSORT macro directly in this file, but the macro's underlying logic is used):
+        *   `isorti`, `isortd`: Sort `idx_t` arrays (increasing, decreasing).
+        *   `rsorti`, `rsortd`: Sort `real_t` arrays (increasing, decreasing).
+        *   `ikvsorti`, `ikvsortii`, `ikvsortd`: Sort `ikv_t` arrays by key (increasing, increasing by key then value, decreasing).
+        *   `rkvsorti`, `rkvsortd`: Sort `rkv_t` arrays by key (increasing, decreasing).
+        *   `uvwsorti`: Sort `uvw_t` arrays (custom struct, by u then v).
+
+## Important Variables/Constants
+
+*   `IDX_MAX`, `REAL_MAX`: Used as initial maximum values in priority queue implementations.
+*   Comparison macros like `key_gt`, `i_lt`, `r_lt`, `ikey_lt`, `ikeyval_lt`, `rkey_lt`, `uvwkey_lt` are defined locally for use with the sorting and priority queue generation.
+
+## Usage Examples
+
+```c
+// These functions are used extensively throughout ParMETIS.
+// Example (conceptual):
+// idx_t *myarray = imalloc(100, "myarray");
+// iset(100, 0, myarray); // Set all elements to 0
+// idx_t sum_val = isum(100, myarray, 1); // Sum elements with stride 1
+// isorti(100, myarray); // Sort the array
+// gk_free((void **)&myarray, LTERM); // Free memory (gk_free is the GKlib memory wrapper)
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: This is the primary include. It, in turn, includes:
+        *   `gklib_defs.h`: Contains typedefs for `ikv_t`, `rkv_t`, `uvw_t`, `ipq_t`, `rpq_t` and prototypes for the functions generated/defined in this `gklib.c` file. These prototypes use the renamed versions (e.g., `libparmetis__iset`).
+        *   `gklib_rename.h`: Contains macros that rename the GKlib functions (e.g., `iset` becomes `libparmetis__iset`) to avoid symbol clashes if ParMETIS is linked with another library that also uses GKlib. The implementations in `gklib.c` define the `libparmetis__*` versions.
+        *   Standard C headers like `<stdio.h>`, `<stdlib.h>`, `<string.h>`, `<stdarg.h>`, `<math.h>` are included via `parmetislib.h` (often through GKlib's own header structure which is partially replicated/adapted in ParMETIS).
+*   **External Libraries**:
+    *   None directly. The necessary GKlib functionality is compiled as part of ParMETIS itself from these templated definitions.
+*   **Other Interactions**:
+    *   This file provides the fundamental building blocks (memory management, array operations, sorting, random numbers, priority queues) that are used by almost all other modules in ParMETIS.
+    *   The renaming scheme (`libparmetis__*`) is crucial for robust linking and avoiding symbol collisions in larger applications.
+
+```

--- a/documentation/gklib_defs.h.md
+++ b/documentation/gklib_defs.h.md
@@ -1,0 +1,74 @@
+# libparmetis/gklib_defs.h
+
+## Overview
+
+This header file serves as a central point for defining data structures and declaring function prototypes related to the embedded GKlib (George Karypis Library) functionality within ParMETIS. It leverages GKlib's template macros to define custom key-value and priority queue types specific to ParMETIS's needs (using `idx_t` and `real_t`). It also lists the prototypes for the various BLAS-like, memory allocation, sorting, random number, and priority queue functions that are implemented in `gklib.c`.
+
+## Key Components
+
+### Functions/Classes/Modules/Macros/Structs
+
+*   **Structure Definitions**:
+    *   `uvw_t`: A structure to store a weighted edge, with fields `u`, `v` (vertex indices) and `w` (weight). All are of type `idx_t`.
+    *   `GK_MKKEYVALUE_T(ikv_t, idx_t, idx_t)`: Macro instantiation defining `ikv_t` as a key-value pair structure where both key and value are `idx_t`.
+    *   `GK_MKKEYVALUE_T(rkv_t, real_t, idx_t)`: Macro instantiation defining `rkv_t` as a key-value pair structure where the key is `real_t` and the value is `idx_t`.
+    *   `GK_MKPQUEUE_T(ipq_t, ikv_t)`: Macro instantiation defining `ipq_t` as the type for a priority queue holding `ikv_t` elements.
+    *   `GK_MKPQUEUE_T(rpq_t, rkv_t)`: Macro instantiation defining `rpq_t` as the type for a priority queue holding `rkv_t` elements.
+
+*   **Function Prototypes**:
+    *   The file lists prototypes for a comprehensive set of utility functions. These functions are implemented in `gklib.c` using GKlib's template mechanism. The prototypes here use the renamed versions (e.g., `libparmetis__iargmax` via `gklib_rename.h`).
+    *   **BLAS-like functions**:
+        *   For `idx_t`: `iargmax`, `iargmin`, `iaxpy`, `icopy`, `idot`, `iincset`, `imax`, `imin`, `inorm2`, `iscale`, `iset`, `isum`. (Prototypes via `GK_MKBLAS_PROTO(i, idx_t, idx_t)`).
+        *   For `real_t`: `rargmax`, `rargmin`, `raxpy`, `rcopy`, `rdot`, `rincset`, `rmax`, `rmin`, `rnorm2`, `rscale`, `rset`, `rsum`. (Prototypes via `GK_MKBLAS_PROTO(r, real_t, real_t)`).
+    *   **Memory Allocation functions**:
+        *   For `idx_t`: `imalloc`, `ismalloc`, `irealloc`, `iAllocMatrix`, `iFreeMatrix`, `iSetMatrix`. (Prototypes via `GK_MKALLOC_PROTO(i, idx_t)`).
+        *   For `real_t`: `rmalloc`, `rsmalloc`, `rrealloc`, etc. (Prototypes via `GK_MKALLOC_PROTO(r, real_t)`).
+        *   For `ikv_t`: `ikvmalloc`, `ikvsmalloc`, etc. (Prototypes via `GK_MKALLOC_PROTO(ikv, ikv_t)`).
+        *   For `rkv_t`: `rkvmalloc`, `rkvsmalloc`, etc. (Prototypes via `GK_MKALLOC_PROTO(rkv, rkv_t)`).
+    *   **Priority Queue functions**:
+        *   For `ipq_t` (holding `ikv_t`): `ipqCreate`, `ipqDestroy`, `ipqInit`, `ipqInsert`, `ipqDelete`, `ipqUpdate`, `ipqGetTop`, `ipqLength`, etc. (Prototypes via `GK_MKPQUEUE_PROTO(ipq, ipq_t, idx_t, idx_t)`).
+        *   For `rpq_t` (holding `rkv_t`): `rpqCreate`, `rpqDestroy`, etc. (Prototypes via `GK_MKPQUEUE_PROTO(rpq, rpq_t, real_t, idx_t)`).
+    *   **Random Number functions**:
+        *   For `idx_t`: `isrand`, `irand`, `irandArrayPermute`, `irandInRange`. (Prototypes via `GK_MKRANDOM_PROTO(i, idx_t, idx_t)`).
+    *   **Utility functions**:
+        *   `iarray2csr`. (Prototype via `GK_MKARRAY2CSR_PROTO(i, idx_t)`).
+    *   **Sorting functions**:
+        *   `isorti`, `isortd` (for `idx_t`).
+        *   `rsorti`, `rsortd` (for `real_t`).
+        *   `ikvsorti`, `ikvsortii`, `ikvsortd` (for `ikv_t`).
+        *   `rkvsorti`, `rkvsortd` (for `rkv_t`).
+        *   `uvwsorti` (for `uvw_t`).
+
+## Important Variables/Constants
+
+This header file itself does not define many constants, but it relies on `idx_t` and `real_t` which are fundamental types defined elsewhere (typically in `parmetislib.h` or its included headers like `metis.h`). The GKlib macros like `GK_MKKEYVALUE_T` and `GK_MKPQUEUE_T` are used to declare new types.
+
+## Usage Examples
+
+```c
+// This is a header file. It's included by other .c files in ParMETIS.
+// Example of how it's used (in another .c file):
+
+#include "parmetislib.h" // This would include gklib_defs.h
+
+// ... later in the code ...
+// ikv_t *my_pairs = ikvmalloc(10, "my_pairs_array"); // Uses prototype from gklib_defs.h
+// iset(params->n, (idx_t)-1, where); // Uses prototype from gklib_defs.h for iset
+// ...
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `gklib_rename.h`: This header is included first. It contains `#define` directives that rename all the GKlib function names to have a `libparmetis__` prefix (e.g., `iset` becomes `libparmetis__iset`). The prototypes in `gklib_defs.h` then declare these renamed functions.
+    *   The actual implementations of these prototyped functions are found in `gklib.c`.
+    *   This header is a core part of `parmetislib.h`, which is the main internal header for the library.
+    *   Relies on `idx_t` and `real_t` type definitions from `metis.h` (included via `parmetislib.h`).
+    *   The GKlib template macros (`GK_MKKEYVALUE_T`, `GK_MKPQUEUE_T`, `GK_MKBLAS_PROTO`, etc.) are defined externally in the GKlib system, but their usage here is to generate ParMETIS-specific code.
+*   **External Libraries**:
+    *   None directly.
+*   **Other Interactions**:
+    *   This file is crucial for the internal organization of ParMETIS, providing a clear interface to the embedded GKlib utility functions.
+    *   The renaming strategy (via `gklib_rename.h`) is essential for preventing symbol clashes when ParMETIS is linked into larger applications that might also use GKlib independently.
+
+```

--- a/documentation/gklib_rename.h.md
+++ b/documentation/gklib_rename.h.md
@@ -1,0 +1,69 @@
+# libparmetis/gklib_rename.h
+
+## Overview
+
+This header file is a critical part of ParMETIS's integration of GKlib (George Karypis Library). Its sole purpose is to rename the standard GKlib function names using C preprocessor macros. Each GKlib function (e.g., `iset`, `imalloc`, `ikvsorti`) is redefined with a `libparmetis__` prefix (e.g., `libparmetis__iset`, `libparmetis__imalloc`, `libparmetis__ikvsorti`).
+
+This renaming strategy is employed to prevent symbol clashes that could occur if a user application links ParMETIS with another library that also uses GKlib, or if the user links against a system-installed version of GKlib. By prefixing these symbols, ParMETIS ensures that it uses its own embedded versions of these utility functions.
+
+## Key Components
+
+### Functions/Classes/Modules/Macros/Structs
+
+This file consists entirely of `#define` preprocessor directives. There are no function, class, or struct definitions.
+
+Examples of redefinitions:
+*   `#define iAllocMatrix libparmetis__iAllocMatrix`
+*   `#define iset libparmetis__iset`
+*   `#define ikvsorti libparmetis__ikvsorti`
+*   `#define imalloc libparmetis__imalloc`
+*   `#define ipqCreate libparmetis__ipqCreate`
+*   `#define rset libparmetis__rset`
+*   `#define rmalloc libparmetis__rmalloc`
+*   `#define rpqCreate libparmetis__rpqCreate`
+*   `#define isorti libparmetis__isorti`
+*   And many more, covering a wide range of GKlib functions for:
+    *   Memory allocation and deallocation for various types (`idx_t`, `real_t`, `ikv_t`, `rkv_t`, matrices).
+    *   Array manipulation (setting, copying, scaling, dot products, argmax, argmin, norm).
+    *   Priority queue operations.
+    *   Random number generation.
+    *   Sorting for various types and criteria.
+    *   CSR conversion utilities.
+
+## Important Variables/Constants
+
+Not applicable, as this file only contains macro definitions for renaming.
+
+## Usage Examples
+
+```c
+// This header file is not directly used by end-users.
+// It's included by parmetislib.h (typically via gklib_defs.h).
+
+// In gklib_defs.h (or other ParMETIS internal files):
+// #include "gklib_rename.h" // This applies the renaming
+// ...
+// // Now, when a ParMETIS internal file calls iset(...), the preprocessor
+// // changes it to libparmetis__iset(...) before compilation.
+// void libparmetis__iset(idx_t n, idx_t val, idx_t *array); // Prototype in gklib_defs.h
+//
+// // In gklib.c:
+// void libparmetis__iset(idx_t n, idx_t val, idx_t *array) { // Implementation
+//   // ...
+// }
+
+```
+When ParMETIS source code is compiled, any call to a standard GKlib function name (like `iset`) is replaced by its `libparmetis__` prefixed version. The actual implementation of these functions (in `gklib.c`) also uses these prefixed names.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   This file is included by `gklib_defs.h`, which is part of the main internal header `parmetislib.h`.
+    *   It directly affects how function calls to GKlib utilities are compiled within ParMETIS. The function implementations in `gklib.c` must define the `libparmetis__*` prefixed names. The function prototypes in `gklib_defs.h` must also declare these prefixed names.
+*   **External Libraries**:
+    *   None. This file only contains preprocessor definitions.
+*   **Other Interactions**:
+    *   This renaming is crucial for avoiding linker errors and ensuring ParMETIS uses its internal version of GKlib utilities, especially when integrated into larger projects that might also use GKlib or have conflicting symbols.
+    *   The list of renamed symbols is generated from the `.o` files using a script (`./utils/listundescapedsumbols.csh`), indicating it's a somewhat automated process to keep the renames comprehensive.
+
+```

--- a/documentation/gkmetis.c.md
+++ b/documentation/gkmetis.c.md
@@ -1,0 +1,80 @@
+# libparmetis/gkmetis.c
+
+## Overview
+
+This file serves as an entry point for ParMETIS routines that perform graph partitioning using geometric information (vertex coordinates). It provides functions that can partition a graph based solely on coordinates or use coordinates to establish an initial distribution for a k-way partitioning algorithm. The key idea is to leverage spatial proximity to guide the partitioning process, which can be particularly effective for graphs derived from geometric meshes.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_V3_PartGeomKway(idx_t *vtxdist, idx_t *xadj, ..., MPI_Comm *comm)`**:
+    *   This is a V3 API function that partitions a distributed graph into `nparts` partitions.
+    *   It first uses geometric partitioning (based on `xyz` coordinates and `ndims`) to achieve an initial `npes`-way partition (distributing the graph among processors).
+    *   Then, it moves the graph data according to this initial partition (`MoveGraph`).
+    *   Finally, it partitions the (now potentially redistributed) local graph on each processor into `nparts/npes` (or similar) local partitions using a parallel k-way partitioning algorithm (`Global_Partition` or `PartitionSmallGraph` for small graphs).
+    *   The final partition is then projected back to the original graph distribution.
+    *   Handles the `npes == 1` case by calling the serial METIS `METIS_PartGraphKway`.
+    *   Handles the `nparts == 1` trivial case.
+*   **`ParMETIS_V3_PartGeom(idx_t *vtxdist, idx_t *ndims, real_t *xyz, idx_t *part, MPI_Comm *comm)`**:
+    *   This is a V3 API function that partitions the vertices based *solely* on their geometric coordinates (`xyz` and `ndims`) into `npes` partitions (one partition per processor).
+    *   It creates a "fake" graph structure because the underlying partitioning machinery (`Coordinate_Partition`) expects a graph.
+    *   The resulting partition assigns each vertex to one of the processors.
+    *   Handles the `npes == 1` trivial case.
+
+## Important Variables/Constants
+
+*   **`xyz`**: Array of real numbers storing the coordinates of the vertices. For `N` vertices and `D` dimensions, this would be an array of size `N*D`.
+*   **`ndims`**: The number of dimensions for the coordinates in `xyz`.
+*   **`vtxdist`**: Standard ParMETIS array defining the distribution of vertices across processors.
+*   **`xadj`, `adjncy`, `vwgt`, `adjwgt`**: Standard graph CSR representation and weights.
+*   **`part`**: Output array where the partition assignments are stored.
+*   **`nparts`**: The desired number of partitions for `ParMETIS_V3_PartGeomKway`.
+*   **`ctrl_t`**: The ParMETIS control structure.
+*   **`graph_t`**: The ParMETIS graph structure.
+*   **`mgraph`**: A "moved graph" structure used in `ParMETIS_V3_PartGeomKway` after the initial geometric distribution.
+*   **`METIS_NOPTIONS`, `METIS_OPTION_NUMBERING`**: Used when calling serial METIS for the `npes == 1` case.
+*   `SMALLGRAPH`: A threshold to decide whether to partition serially or in parallel after the initial geometric distribution.
+
+## Usage Examples
+
+```c
+// Conceptual call to ParMETIS_V3_PartGeomKway
+// (assuming all parameters like vtxdist, xadj, xyz, part, comm are set up)
+// idx_t options[PARMETIS_MAX_OPTIONS];
+// options[0] = 0; // Use default options
+// idx_t edgecut;
+// ParMETIS_V3_PartGeomKway(vtxdist, xadj, adjncy, vwgt, adjwgt,
+//                          &wgtflag, &numflag, &ndims, xyz,
+//                          &ncon, &nparts, tpwgts, ubvec,
+//                          options, &edgecut, part, &comm);
+
+// Conceptual call to ParMETIS_V3_PartGeom
+// idx_t part[nvtxs_local];
+// ParMETIS_V3_PartGeom(vtxdist, &ndims, xyz_local, part, &comm);
+// // part now contains the PE assignment for each local vertex.
+```
+These are API functions intended to be called by user applications.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides core data structures (`ctrl_t`, `graph_t`), type definitions, and prototypes for many internal functions.
+    *   `ctrl.c`: For `SetupCtrl`, `FreeCtrl`.
+    *   `graph.c`: For `SetupGraph`, `MoveGraph`, `FreeGraph`, `FreeInitialGraphAndRemap`, `SetupGraph_nvwgts`.
+    *   `wspace.c`: For `AllocateWSpace`.
+    *   `xyzpart.c`: For `Coordinate_Partition` (the core geometric partitioning routine).
+    *   `kmetis.c` (indirectly): For `Global_Partition` (parallel k-way partitioning).
+    *   `serial.c`: For `PartitionSmallGraph`.
+    *   `remap.c`: For `ParallelReMapGraph`, `ProjectInfoBack`.
+    *   `util.c`: For `ChangeNumbering`.
+    *   `comm.c`: For `GlobalSEMinComm`, `GlobalSESum`, `GlobalSEMax`, `CommInterfaceData`.
+    *   `metis.h` (external METIS library): For `METIS_PartGraphKway`, `METIS_SetDefaultOptions` when `npes == 1`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For all parallel communication.
+    *   `METIS`: The serial METIS library is called as a fallback if `npes == 1`.
+*   **Other Interactions**:
+    *   These functions are often used as a first step in partitioning physical meshes, where vertex coordinates provide a good heuristic for initial partitioning.
+    *   The quality of the geometric partition can influence the final result of `ParMETIS_V3_PartGeomKway`.
+
+```

--- a/documentation/gkmpi.c.md
+++ b/documentation/gkmpi.c.md
@@ -1,0 +1,78 @@
+# libparmetis/gkmpi.c
+
+## Overview
+
+This file provides a set of wrapper functions around standard MPI (Message Passing Interface) calls. The primary purpose of these wrappers is to allow ParMETIS to use its own `idx_t` type for counts and displacements in MPI calls, rather than being restricted to `int`. This is important for handling very large graphs where the number of vertices or edges might exceed the maximum value representable by a standard `int`.
+
+The wrappers conditionally compile to use either the standard MPI functions (if `MPI_VERSION < 4` and `IDXTYPEWIDTH == 32`) or the newer MPI 4.0 `_c` suffixed functions that accept `MPI_Count` (which can be larger than `int`). For cases where `MPI_VERSION < 4` but `IDXTYPEWIDTH == 64` (meaning `idx_t` is 64-bit), these wrappers include logic to check for potential overflow if `idx_t` values are too large for `int`, and will call `errexit` if such an overflow is detected for collective operations that pass arrays of counts/displacements.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+Each function is a wrapper around a standard MPI function. The wrappers handle the potential type mismatch between `idx_t` and `int` or `MPI_Count`.
+
+*   **`gkMPI_Comm_size(MPI_Comm comm, idx_t *size)`** wraps `MPI_Comm_size`.
+*   **`gkMPI_Comm_rank(MPI_Comm comm, idx_t *rank)`** wraps `MPI_Comm_rank`.
+*   **`gkMPI_Get_count(MPI_Status *status, MPI_Datatype datatype, idx_t *count)`** wraps `MPI_Get_count` or `MPI_Get_count_c`.
+*   **`gkMPI_Send(void *buf, idx_t count, ..., MPI_Comm comm)`** wraps `MPI_Send` or `MPI_Send_c`.
+*   **`gkMPI_Recv(void *buf, idx_t count, ..., MPI_Comm comm, MPI_Status *status)`** wraps `MPI_Recv` or `MPI_Recv_c`.
+*   **`gkMPI_Isend(void *buf, idx_t count, ..., MPI_Request *request)`** wraps `MPI_Isend` or `MPI_Isend_c`.
+*   **`gkMPI_Irecv(void *buf, idx_t count, ..., MPI_Request *request)`** wraps `MPI_Irecv` or `MPI_Irecv_c`.
+*   **`gkMPI_Wait(MPI_Request *request, MPI_Status *status)`** wraps `MPI_Wait`.
+*   **`gkMPI_Waitall(idx_t count, MPI_Request *array_of_requests, ...)`** wraps `MPI_Waitall`.
+*   **`gkMPI_Barrier(MPI_Comm comm)`** wraps `MPI_Barrier`.
+*   **`gkMPI_Bcast(void *buffer, idx_t count, ..., MPI_Comm comm)`** wraps `MPI_Bcast` or `MPI_Bcast_c`.
+*   **`gkMPI_Reduce(void *sendbuf, void *recvbuf, idx_t count, ..., MPI_Comm comm)`** wraps `MPI_Reduce` or `MPI_Reduce_c`.
+*   **`gkMPI_Allreduce(void *sendbuf, void *recvbuf, idx_t count, ..., MPI_Comm comm)`** wraps `MPI_Allreduce` or `MPI_Allreduce_c`.
+*   **`gkMPI_Scan(void *sendbuf, void *recvbuf, idx_t count, ..., MPI_Comm comm)`** wraps `MPI_Scan` or `MPI_Scan_c`.
+*   **`gkMPI_Allgather(void *sendbuf, idx_t sendcount, ..., MPI_Comm comm)`** wraps `MPI_Allgather` or `MPI_Allgather_c`.
+*   **`gkMPI_Alltoall(void *sendbuf, idx_t sendcount, ..., MPI_Comm comm)`** wraps `MPI_Alltoall` or `MPI_Alltoall_c`.
+*   **`gkMPI_Alltoallv(void *sendbuf, idx_t *sendcounts, ..., MPI_Comm comm)`**:
+    *   Wraps `MPI_Alltoallv` or `MPI_Alltoallv_c`.
+    *   If `MPI_VERSION < 4` and `IDXTYPEWIDTH == 64`, it dynamically allocates temporary `int` arrays for counts/displacements, copies `idx_t` values, checks for overflow, calls `MPI_Alltoallv`, and copies results back.
+*   **`gkMPI_Allgatherv(void *sendbuf, idx_t sendcount, ..., MPI_Comm comm)`**:
+    *   Wraps `MPI_Allgatherv` or `MPI_Allgatherv_c`.
+    *   Similar overflow checks and temporary array usage as `gkMPI_Alltoallv` for the 64-bit `idx_t` / MPI 3.x case.
+*   **`gkMPI_Scatterv(void *sendbuf, idx_t *sendcounts, ..., MPI_Comm comm)`**:
+    *   Wraps `MPI_Scatterv` or `MPI_Scatterv_c`.
+    *   Similar overflow checks and temporary array usage.
+*   **`gkMPI_Gatherv(void *sendbuf, idx_t sendcount, ..., MPI_Comm comm)`**:
+    *   Wraps `MPI_Gatherv` or `MPI_Gatherv_c`.
+    *   Similar overflow checks and temporary array usage.
+*   **`gkMPI_Comm_split(MPI_Comm comm, idx_t color, idx_t key, MPI_Comm *newcomm)`** wraps `MPI_Comm_split`.
+*   **`gkMPI_Comm_free(MPI_Comm *comm)`** wraps `MPI_Comm_free`.
+*   **`gkMPI_Finalize()`** wraps `MPI_Finalize`.
+
+## Important Variables/Constants
+
+*   **`MPI_VERSION`**: Preprocessor macro used to check the version of the MPI standard.
+*   **`IDXTYPEWIDTH`**: Preprocessor macro (likely 32 or 64) indicating the bit width of `idx_t`.
+*   **`INT_MAX`**: Used for overflow checking when `IDXTYPEWIDTH == 64` and `MPI_VERSION < 4`.
+
+## Usage Examples
+
+```c
+// Internal ParMETIS code would call these gkMPI_* functions instead of direct MPI calls.
+// Example:
+// idx_t nsend = graph->sendptr[i+1] - graph->sendptr[i];
+// gkMPI_Isend((void *)(sendbuffer + graph->sendptr[i]), nsend, IDX_T,
+//             neighbor_pe, tag, ctrl->comm, ctrl->sreq + i);
+
+// idx_t global_sum;
+// idx_t local_val = 10;
+// gkMPI_Allreduce((void *)&local_val, (void *)&global_sum, 1, IDX_T, MPI_SUM, ctrl->comm);
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `idx_t` type definition, `errexit` function for error handling, and memory management like `gk_imalloc`, `gk_free` (used for temporary buffers in the 64-bit `idx_t` / MPI 3.x case).
+    *   These wrappers are used by other ParMETIS modules that perform MPI communication (e.g., `comm.c`, `diffutil.c`, `initbalance.c`).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: This entire file consists of wrappers around MPI library calls. The behavior depends on the MPI version available at compile time.
+*   **Other Interactions**:
+    *   The conditional compilation based on `MPI_VERSION` and `IDXTYPEWIDTH` ensures that ParMETIS can be compiled with different MPI libraries and for different `idx_t` sizes while maintaining correctness for large datasets.
+    *   The overflow checks and error exits are crucial for safety when using 64-bit `idx_t` with older MPI versions that expect `int` for counts/displacements in some vector collective operations.
+
+```

--- a/documentation/graph.c.md
+++ b/documentation/graph.c.md
@@ -1,0 +1,87 @@
+# libparmetis/graph.c
+
+## Overview
+
+This file contains routines for managing the `graph_t` data structure in ParMETIS. This includes functions for creating, initializing, and freeing graph structures, as well as setting up various graph attributes like normalized vertex weights (`nvwgt`). It also includes experimental functionality for writing and reading graph data to/from disk to potentially save memory for very large graphs during multilevel processing.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`SetupGraph(ctrl_t *ctrl, idx_t ncon, idx_t *vtxdist, idx_t *xadj, idx_t *vwgt, idx_t *vsize, idx_t *adjncy, idx_t *adjwgt, idx_t wgtflag)`**:
+    *   Creates and initializes a `graph_t` structure from user-provided raw graph data.
+    *   Sets basic graph properties: `nvtxs`, `nedges`, `ncon`, CSR arrays (`xadj`, `adjncy`), `vtxdist`.
+    *   Allocates and initializes vertex weights (`vwgt`) and edge weights (`adjwgt`) if not provided by the user (based on `wgtflag`).
+    *   Allocates `vsize` (vertex sizes) and `home` arrays if the operation type is adaptive or refinement.
+    *   Calculates `ctrl->edge_size_ratio`.
+    *   Computes inverse total vertex weights (`SetupCtrl_invtvwgts`).
+    *   Computes normalized vertex weights (`SetupGraph_nvwgts`).
+*   **`SetupGraph_nvwgts(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Computes the normalized vertex weights (`graph->nvwgt`) for each constraint.
+    *   `nvwgt[i*ncon+j] = graph->vwgt[i*ncon+j] * ctrl->invtvwgts[j]`.
+*   **`CreateGraph(void)`**:
+    *   Allocates memory for a `graph_t` structure and initializes its fields to default null/invalid values using `InitGraph`.
+*   **`InitGraph(graph_t *graph)`**:
+    *   Sets all fields of a `graph_t` structure to zero or default invalid values (e.g., -1, NULL).
+    *   Initializes `free_*` flags to 1 (indicating ParMETIS should free these arrays).
+*   **`FreeGraph(graph_t *graph)`**:
+    *   Frees all memory associated with a `graph_t` structure, including base graph arrays (xadj, vwgt, etc.) and other auxiliary arrays (match, cmap, where, etc.). It calls `FreeNonGraphFields`.
+*   **`FreeNonGraphFields(graph_t *graph)`**:
+    *   Frees most auxiliary arrays within the `graph_t` structure, excluding the primary graph data (xadj, adjncy, vwgt, adjwgt, vsize, vtxdist, nvwgt, home).
+*   **`FreeNonGraphNonSetupFields(graph_t *graph)`**:
+    *   Frees auxiliary arrays similar to `FreeNonGraphFields` but also keeps communication setup related fields.
+*   **`FreeCommSetupFields(graph_t *graph)`**:
+    *   Specifically frees arrays related to communication setup (lperm, peind, sendptr, etc.).
+*   **`FreeInitialGraphAndRemap(graph_t *graph)`**:
+    *   Frees a graph structure after partitioning, including performing a local-to-global remapping of `adjncy` if `graph->imap` exists.
+    *   Selectively frees `vwgt`, `adjwgt`, `vsize` based on their `free_*` flags.
+*   **`graph_WriteToDisk(ctrl_t *ctrl, graph_t *graph)`**:
+    *   (Experimental) If `ctrl->ondisk` is enabled and graph size exceeds a threshold, writes key graph arrays (xadj, vwgt, nvwgt, adjncy, adjwgt, vsize, home) to a binary file.
+    *   Frees these arrays from memory after writing. Sets `graph->ondisk = 1`.
+*   **`graph_ReadFromDisk(ctrl_t *ctrl, graph_t *graph)`**:
+    *   (Experimental) If `graph->ondisk` is set, reads the graph data previously written by `graph_WriteToDisk` back into memory.
+    *   Deletes the disk file after reading.
+
+## Important Variables/Constants
+
+*   **`graph_t` (struct)**: The central data structure for representing distributed graphs. Key members include:
+    *   `nvtxs`, `nedges`, `ncon`: Local number of vertices, edges, constraints.
+    *   `gnvtxs`: Global number of vertices.
+    *   `xadj`, `adjncy`, `vwgt`, `adjwgt`, `vsize`: CSR graph structure and weights.
+    *   `nvwgt`: Normalized vertex weights.
+    *   `vtxdist`: Distribution of vertices to PEs.
+    *   `home`: Original partition/PE of a vertex (for adaptive/refinement).
+    *   `where`: Current partition assignment.
+    *   Communication fields: `peind`, `sendptr`, `sendind`, `recvptr`, `recvind`, `imap`, `pexadj`, etc. (managed by `comm.c`).
+    *   Coarsening fields: `match`, `cmap`.
+    *   `coarser`, `finer`: Pointers to graphs at different levels in the multilevel hierarchy.
+    *   `free_xadj`, `free_vwgt`, etc.: Flags indicating if ParMETIS allocated and is responsible for freeing these arrays.
+    *   `ondisk`, `gID`: Fields for managing on-disk storage of graph data.
+*   **`ctrl_t` (struct)**: Control structure, used for `optype`, `mype`, `npes`, `ondisk` flag, `invtvwgts`.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions.
+*   `SetupGraph` is called at the beginning of most ParMETIS API functions to convert user input into the internal `graph_t` format.
+*   `CreateGraph`/`InitGraph` are used when building new graph structures (e.g., coarser graphs).
+*   The `Free*` functions are used for memory management throughout the lifecycle of graph structures, especially in the multilevel coarsening/refinement process.
+*   `graph_WriteToDisk` and `graph_ReadFromDisk` might be called during multilevel algorithms if the `ondisk` option is active to reduce memory footprint.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `graph_t` definitions, `idx_t`, `real_t` types, memory management (`gk_malloc`, `ismalloc`, `rmalloc`, `gk_free`, `memset`), and GKlib utilities (like `isum` used via `ctrl.c`).
+    *   `ctrl.c`: `SetupCtrl_invtvwgts` is called by `SetupGraph`.
+    *   `comm.c`: The communication fields initialized as `NULL` here are populated by `CommSetup` from `comm.c`.
+    *   The `graph_t` structure is fundamental and is passed to nearly all ParMETIS functions.
+*   **External Libraries**:
+    *   Standard C I/O (`stdio.h`): Used for `fopen`, `fwrite`, `fread`, `fclose` in `graph_WriteToDisk`/`graph_ReadFromDisk`.
+    *   Standard C library (`string.h` for `memset`).
+*   **Other Interactions**:
+    *   The `free_*` flags in `graph_t` determine whether ParMETIS reclaims memory for graph arrays or assumes the user will manage them (if they were passed in and `wgtflag` indicated user-provided arrays).
+    *   The on-disk functionality creates temporary files named `parmetis<PE>.<PID>.<gID>`.
+
+```

--- a/documentation/initbalance.c.md
+++ b/documentation/initbalance.c.md
@@ -1,0 +1,64 @@
+# libparmetis/initbalance.c
+
+## Overview
+
+This file implements routines for computing an initial balanced partitioning of a distributed graph, particularly in scenarios where an existing partition might be imbalanced or when a starting point for refinement is needed. The primary function `Balance_Partition` assembles the entire graph on all processors (or groups of processors) and then uses serial METIS routines or specialized internal methods (like diffusion) to compute a balanced partition. It can explore multiple strategies and pick the best one.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`Balance_Partition(ctrl_t *ctrl, graph_t *graph)`**:
+    *   This is the main function for achieving an initial balanced partition.
+    *   It first assembles the entire graph structure and weights onto each processor or within subgroups of processors using `AssembleAdaptiveGraph`. The assembled graph is referred to as `agraph`.
+    *   It initializes a `home` array for `agraph` based on the original partitioning (`graph->home` or processor ID if coupled).
+    *   It then splits the processors into two groups (if `ncon <= MAX_NCON_FOR_DIFFUSION` and `npes > 1`):
+        *   **Group 1 (Scratch-Remap)**: Further subdivides its processors. Each subgroup recursively bisects its portion of the assembled graph using serial `METIS_PartGraphRecursive` or `METIS_PartGraphKway` to generate a candidate partition. Results are combined, and the best among these subgroups (based on cut and balance) is selected. This best partition is then potentially remapped using `SerialRemap` for better contiguity.
+        *   **Group 2 (Diffusion)**: Uses diffusion-based methods (`WavefrontDiffusion` for `ncon=1` or `Mc_Diffusion` for multi-constraint) on the assembled graph to generate another candidate partition. The best result from this group is also selected and potentially remapped.
+    *   If only one strategy is used (e.g., due to `ncon` or `npes`), that result is taken.
+    *   The best partition between the "scratch-remap" group and the "diffusion" group is chosen based on a cost function involving cut and balance.
+    *   The final chosen partition for the assembled graph is then broadcasted and scattered back to update `graph->where` on each processor for its local portion of the original distributed graph.
+*   **`AssembleAdaptiveGraph(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Gathers the entire distributed graph (`graph`) onto every processor.
+    *   Each processor sends its local graph data (CSR structure, vertex weights, vertex sizes if applicable) to all other processors using `gkMPI_Allgatherv`.
+    *   Each processor then reconstructs the full graph (`agraph`) from the received data.
+    *   `agraph->label` is initialized to store the original global vertex indices.
+    *   Normalized vertex weights (`anvwgt`) are computed for `agraph`.
+
+## Important Variables/Constants
+
+*   **`agraph` (graph_t)**: The assembled graph structure containing the entire graph data, replicated on processors or subgroups.
+*   **`home` (idx_t array)**: Stores the initial partition or PE assignment for vertices in `agraph`.
+*   **`part` (idx_t array)**: Used to store the computed partition for `agraph`.
+*   **`lwhere` (idx_t array)**: Temporary array for partition storage during parallel computations.
+*   **`ctrl->ps_relation`**: Determines how `home` is initialized (`PARMETIS_PSR_COUPLED` vs. `PARMETIS_PSR_UNCOUPLED`).
+*   **`ctrl->tpwgts`**: Target partition weights, used by METIS calls and remapping.
+*   **`MAX_NCON_FOR_DIFFUSION`**: Constant determining if diffusion methods are attempted (usually for low numbers of constraints).
+*   **`RIP_SPLIT_FACTOR`**: Factor for splitting processor groups in scratch-remap.
+*   **`REDIST_WGT`**: Weight factor for redistribution cost in cost evaluation.
+*   MPI Communicators: `ipcomm` (for subgroups), `srcomm` (for scratch-remap subgroups).
+
+## Usage Examples
+
+```
+N/A
+```
+This is an internal ParMETIS function. `Balance_Partition` is typically called by higher-level routines like `AdaptiveRepart` when the initial partition is imbalanced or needs to be established before refinement.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `graph_t` definitions, constants, MPI wrappers, memory utilities, etc.
+    *   `graph.c`: `AssembleAdaptiveGraph` uses `CreateGraph`, `imalloc`, `rmalloc`, `icopy`, `iincset`, `MAKECSR`. `Balance_Partition` uses `AssembleAdaptiveGraph`, `FreeGraph`.
+    *   `diffutil.c`: `WavefrontDiffusion`, `Mc_Diffusion` are called if the diffusion strategy is chosen.
+    *   `serial.c`: `SerialRemap`, `KeepPart`, `ComputeSerialEdgeCut`, `ComputeSerialBalance`.
+    *   `ctrl.c`: For `AllocateWSpace`, `AllocateRefinementWorkSpace`, `FreeCtrl` (for temporary ctrl).
+    *   `metis.h` (external METIS library): `METIS_SetDefaultOptions`, `METIS_PartGraphRecursive`, `METIS_PartGraphKway`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used extensively for communication (`gkMPI_Allgatherv`, `gkMPI_Allreduce`, `gkMPI_Send`, `gkMPI_Recv`, `gkMPI_Bcast`, `gkMPI_Comm_split`, `gkMPI_Comm_rank`, `gkMPI_Comm_size`, `gkMPI_Comm_free`).
+    *   `METIS`: Serial METIS library is used by the "scratch-remap" strategy to partition the assembled graph.
+*   **Other Interactions**:
+    *   The choice between scratch-remap and diffusion strategies, and the selection of the final best partition, depend on the number of constraints and the resulting quality (cut, balance, cost).
+    *   Modifies `graph->where` with the new balanced partition.
+
+```

--- a/documentation/initmsection.c.md
+++ b/documentation/initmsection.c.md
@@ -1,0 +1,60 @@
+# libparmetis/initmsection.c
+
+## Overview
+
+This file implements the initial k-way multisection algorithm for ParMETIS. It's designed to find vertex separators that divide a graph (or parts of it) into multiple sections simultaneously. The process involves assembling the graph, splitting processors into groups, having each group compute a bisection (separator) of its assigned part of the graph using serial METIS, and then selecting the best separator among the groups. The final partitioning, including separators, is encoded in the `graph->where` array.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`InitMultisection(ctrl_t *ctrl, graph_t *graph)`**:
+    *   The main entry point for computing an initial multisection.
+    *   It first assembles the graph from all processors onto each processor within defined subgroups using `AssembleMultisectedGraph`. The assembled graph is `agraph`.
+    *   Processors are split into `ctrl->nparts / 2` groups using `MPI_Comm_split`. Each group is responsible for finding a 2-way separator for a distinct portion of the graph.
+    *   `mypart = ctrl->mype % (ctrl->nparts / 2)` determines which part of the graph this PE group focuses on.
+    *   `KeepPart` is called to isolate the relevant subgraph within `agraph` for each processor group.
+    *   Serial METIS (`METIS_ComputeVertexSeparator`) is called by each group on its subgraph to find a 2-way separator (partitions 0, 1, and separator 2).
+    *   The local separator result (0, 1, 2) is then re-labeled globally: vertices in partition 0 of subproblem `mypart` become `2*mypart`, partition 1 becomes `2*mypart + 1`, and separator vertices become `ctrl->nparts + 2*mypart`.
+    *   Within each group, the processor that found the minimum cut bisection communicates its result to the root of its group (`myrank == 0`).
+    *   The roots of these groups (where `myrank == 0`) then use another MPI communicator (`labelcomm`) and `MPI_Reduce` (MPI_SUM) to combine their separator results into the global `part` array for `agraph`. (Note: Summing labels might be a way to ensure all parts are covered, assuming non-overlap from `KeepPart` logic).
+    *   The final global `part` array (representing the multisection for the entire assembled graph) is scattered from PE 0 (of `ctrl->comm`) to all PEs, updating their local `graph->where` arrays.
+*   **`AssembleMultisectedGraph(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Gathers the entire distributed graph (`graph`) onto every processor (similar to `AssembleAdaptiveGraph` but tailored for multisection, specifically handling single-constraint vertex weights and initial `where` values).
+    *   Each processor sends its local graph data (CSR structure, `vwgt[i]`, `where[i]`) to all other processors using `gkMPI_Allgatherv`.
+    *   Each processor reconstructs the full graph (`agraph`) from the received data.
+    *   `agraph->label` stores original global vertex indices. `agraph->where` stores initial partition assignments from input `graph->where`.
+
+## Important Variables/Constants
+
+*   **`agraph` (graph_t)**: The assembled graph structure containing the entire graph data, replicated on processors or subgroups.
+*   **`part` (idx_t array)**: Used to store the computed global multisection partition for `agraph`.
+*   **`label` (idx_t array in `agraph`)**: Stores the original global indices of vertices in `agraph`.
+*   **`ctrl->nparts`**: On input, this usually indicates the number of desired partitions *after* the multisection (e.g., if `nparts=2`, it's a bisection; if `nparts=4`, it means an existing 2-way partition is further bisected). The output `where` array uses labels up to `ctrl->nparts + 2*(mypart_max)`.
+*   **`METIS_OPTION_NSEPS`**: Option for `METIS_ComputeVertexSeparator` specifying how many separators to try.
+*   **`METIS_OPTION_UFACTOR`**: Imbalance factor for METIS.
+*   MPI Communicators: `newcomm` (for PE groups working on one sub-bisection), `labelcomm` (for PEs with `myrank==0` in their `newcomm` to combine results).
+
+## Usage Examples
+
+```
+N/A
+```
+This is an internal ParMETIS function, typically called during multilevel partitioning (e.g., by `MultilevelBisect` or similar functions in `kmetis.c` or `ometis.c`) to find separators on the coarsest graph.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `graph_t` definitions, MPI wrappers, memory utilities.
+    *   `graph.c`: `AssembleMultisectedGraph` uses `CreateGraph`, `imalloc`, `iincset`, `MAKECSR`. `InitMultisection` uses `AssembleMultisectedGraph`, `FreeGraph`.
+    *   `serial.c`: `KeepPart` is used to isolate parts of the assembled graph.
+    *   `metis.h` (external METIS library): `METIS_SetDefaultOptions`, `METIS_ComputeVertexSeparator`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for communication (`gkMPI_Comm_split`, `gkMPI_Comm_rank`, `gkMPI_Allreduce`, `gkMPI_Send`, `gkMPI_Recv`, `gkMPI_Reduce`, `gkMPI_Scatterv`, `gkMPI_Comm_free`).
+    *   `METIS`: The serial METIS library is used to compute vertex separators on subgraphs.
+*   **Other Interactions**:
+    *   The input `graph->where` array can specify an existing partition that needs to be further multisectioned.
+    *   The output `graph->where` array is encoded such that partitions `0` to `nparts-1` are the sections, and partitions from `nparts` onwards represent the separators themselves (with a formula to link separator parts to the original sections they divide).
+    *   This function is a key step in parallel multilevel k-way partitioning or ordering algorithms that rely on recursive bisection/multisection.
+
+```

--- a/documentation/initpart.c.md
+++ b/documentation/initpart.c.md
@@ -1,0 +1,66 @@
+# libparmetis/initpart.c
+
+## Overview
+
+This file implements an initial graph partitioning algorithm for ParMETIS based on parallel multilevel recursive bisection. The core idea is to assemble the entire graph on groups of processors and then perform a sequence of recursive bisections in parallel to achieve the desired number of partitions. This method is used to get a starting partition, which can then be refined by other algorithms.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`InitPartition(ctrl_t *ctrl, graph_t *graph)`**:
+    *   This is the main entry point for the recursive bisection based initial partitioning.
+    *   It first assembles the entire graph (`agraph`) onto subgroups of processors using `AssembleAdaptiveGraph`.
+    *   Processors are split into `ngroups` (e.g., `RIP_SPLIT_FACTOR`) using `MPI_Comm_split`. Each group then independently computes a full k-way partition.
+    *   **Recursive Bisection within each group**:
+        *   Each processor group (communicator `ipcomm`) performs a recursive bisection process.
+        *   In each step of the recursion, the current graph/subgraph (`agraph` which gets progressively smaller) is bisected using `METIS_PartGraphRecursive`. The target weights for the bisection (`tpwgts2`) are derived from the overall target weights (`ctrl->tpwgts`).
+        *   Processors within the group then decide which part of the bisection to follow based on their rank (`mype`) within the group. `KeepPart` is called to prune `agraph` to only the vertices belonging to the selected part.
+        *   This continues until either the number of PEs in the subgroup (`lnpes`) is 1 or the number of remaining parts to be found (`lnparts`) is 1.
+        *   If `lnparts > 1` when `lnpes == 1` (meaning one PE needs to find multiple partitions for its remaining subgraph), `METIS_PartGraphKway` is called to complete the partitioning for that subgraph.
+    *   The resulting partition for the entire graph (from the perspective of each group) is stored in `gwhere1`.
+    *   If multiple groups (`ngroups > 1`) were used, a selection process occurs:
+        *   Each group computes the edge cut and balance of its computed partition (`gwhere1`) on the original full graph.
+        *   The partition that yields the overall best quality (minimum cut, or if cuts are similar, best balance) is selected using `MPI_Allreduce` with `MPI_MINLOC`.
+        *   The winning partition is then broadcast (`gkMPI_Bcast`) to all processors.
+    *   The final chosen partition is scattered from `gwhere1` to the local `graph->where` array on each processor.
+*   **`KeepPart(ctrl_t *ctrl, graph_t *graph, idx_t *part, idx_t mypart)`**:
+    *   A utility function that modifies the input `graph` structure to contain only the vertices belonging to a specified partition `mypart`.
+    *   It compacts `graph->xadj`, `graph->vwgt`, `graph->adjncy`, `graph->adjwgt`, and `graph->label` by removing vertices not in `mypart`.
+    *   The `rename` array is used to map old vertex indices to new compacted indices. Adjacency lists are updated with these new indices.
+
+## Important Variables/Constants
+
+*   **`agraph` (graph_t)**: The assembled graph structure containing the entire graph data, used by each processor group for recursive bisection.
+*   **`part` (idx_t array in `InitPartition`)**: Temporary array to store partition assignments during METIS calls.
+*   **`gwhere0`, `gwhere1` (idx_t arrays in `InitPartition`)**: Arrays to store the full graph partition computed by each processor group.
+*   **`ctrl->tpwgts`**: Target partition weights for the overall k-way partition.
+*   **`tpwgts2`**: Target weights for a 2-way bisection, derived from `ctrl->tpwgts`.
+*   **`RIP_SPLIT_FACTOR`**: Constant from `defs.h` suggesting how many groups to split PEs into.
+*   **`moptions`**: Array for METIS options, including seed and potentially performance-tuning flags if `ctrl->fast` is set.
+*   MPI Communicators: `ipcomm` (for processor groups).
+
+## Usage Examples
+
+```
+N/A
+```
+This is an internal ParMETIS function. `InitPartition` is typically called by `Global_Partition` (in `kmetis.c`) when a graph needs an initial k-way partition from scratch, especially when the graph is deemed large enough for parallel processing but no prior partitioning information is available.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `graph_t` definitions, MPI wrappers, memory utilities, etc.
+    *   `initbalance.c`: `AssembleAdaptiveGraph` is used to gather the graph.
+    *   `serial.c`: `KeepPart` (though defined in this file, it's a utility for graph manipulation), `ComputeSerialEdgeCut`, `ComputeSerialBalance`.
+    *   `graph.c`: For `FreeGraph`, `icopy`.
+    *   `metis.h` (external METIS library): `METIS_SetDefaultOptions`, `METIS_PartGraphRecursive`, `METIS_PartGraphKway`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for communication (`gkMPI_Comm_split`, `gkMPI_Comm_rank`, `gkMPI_Comm_size`, `gkMPI_Allreduce`, `gkMPI_Bcast`, `gkMPI_Comm_free`).
+    *   `METIS`: The serial METIS library is used as the core engine for recursive bisection and k-way partitioning on the assembled graph data within each processor group.
+*   **Other Interactions**:
+    *   The function modifies `graph->where` with the computed initial partition.
+    *   The quality of the initial partition generated here can significantly affect the subsequent refinement phases and the final partitioning quality.
+    *   The use of multiple processor groups trying different random seeds (`ctrl->sync + (ctrl->mype % ngroups) + 1`) is a way to explore different partitioning solutions and pick the best one.
+
+```

--- a/documentation/io.c.md
+++ b/documentation/io.c.md
@@ -1,0 +1,78 @@
+# programs/io.c
+
+## Overview
+
+This file contains I/O utility functions specifically for the ParMETIS executable programs (drivers/tests like `parmetis`, `mtest`, `ptest`, `otest`). It includes functions to read distributed graphs from files where each processor reads its portion, read mesh data, read coordinate files, and write partition vectors or ordering vectors to files. It handles both standard METIS graph formats and potentially specialized formats for coordinates or meshes.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParallelReadGraph(graph_t *graph, char *filename, MPI_Comm comm)`**:
+    *   Reads a distributed graph in METIS format. PE `npes-1` reads the header (number of vertices, edges, format code), broadcasts this info, and then each PE reads its assigned portion of the graph file.
+    *   The file is assumed to be a single global graph file. PE `npes-1` reads chunks of the file and sends relevant lines/data to other PEs. This is a somewhat complex way to read a serial file in parallel.
+    *   Handles vertex weights (`vwgt`) and edge weights (`adjwgt`) based on the format code.
+    *   Populates the local `graph_t` structure on each PE.
+*   **`Mc_ParallelWriteGraph(ctrl_t *ctrl, graph_t *graph, char *filename, idx_t nparts, idx_t testset)`**:
+    *   Writes a distributed graph to a file in METIS format.
+    *   PE 0 writes the header. Then, each PE (in order) appends its local graph data to the file.
+    *   The output filename is constructed using `filename`, `testset` (likely an identifier), `graph->ncon`, and `nparts`.
+*   **`ReadTestGraph(graph_t *graph, char *filename, MPI_Comm comm)`**:
+    *   Reads a graph in METIS format, but PE 0 reads the entire graph and then scatters it to other PEs.
+    *   `vtxdist` is computed to distribute the graph.
+    *   `xadj` and `adjncy` are sent from PE 0 to other PEs.
+*   **`ReadTestCoordinates(graph_t *graph, char *filename, idx_t *r_ndims, MPI_Comm comm)`**:
+    *   Reads vertex coordinates from a file.
+    *   PE 0 reads the entire coordinate file, determines `ndims` from the first line.
+    *   PE 0 then sends the relevant portions of the coordinate data to other PEs.
+*   **`ReadMetisGraph(char *filename, idx_t *r_nvtxs, idx_t **r_xadj, idx_t **r_adjncy)`**:
+    *   A serial function (callable by any PE, but typically PE 0) to read an entire graph in METIS format from a file.
+    *   Allocates and returns `xadj` and `adjncy`.
+*   **`Mc_SerialReadGraph(graph_t *graph, char *filename, idx_t *wgtflag, MPI_Comm comm)`**:
+    *   PE 0 reads an entire graph in METIS format (using `Mc_SerialReadMetisGraph`) and then distributes it among all PEs.
+    *   Handles vertex and edge weights based on `wgtflag` and format code.
+*   **`Mc_SerialReadMetisGraph(char *filename, idx_t *r_nvtxs, idx_t *r_ncon, idx_t *r_nobj, idx_t *r_fmt, idx_t **r_xadj, idx_t **r_vwgt, idx_t **r_adjncy, idx_t **r_adjwgt, idx_t *wgtflag)`**:
+    *   A serial function to read a METIS graph file, supporting multi-constraint and multi-objective information if present in the format line.
+    *   Populates all relevant graph arrays.
+*   **`WritePVector(char *gname, idx_t *vtxdist, idx_t *part, MPI_Comm comm)`**:
+    *   Writes a distributed partition vector `part` to a file named `<gname>.part`.
+    *   PE 0 gathers the partition vector segments from all other PEs and writes them sequentially.
+*   **`WriteOVector(char *gname, idx_t *vtxdist, idx_t *order, MPI_Comm comm)`**:
+    *   Writes a distributed ordering vector `order` to a file named `<gname>.order.<npes>`.
+    *   PE 0 gathers the ordering vector segments and writes them. It also performs a check to ensure the global ordering is a valid permutation.
+*   **`ParallelReadMesh(mesh_t *mesh, char *filename, MPI_Comm comm)`**:
+    *   Reads a distributed mesh. PE `npes-1` reads header (number of elements, type), broadcasts it.
+    *   Then, PE `npes-1` reads the element connectivity line by line and sends to appropriate PEs.
+    *   Normalizes node numbering based on global min/max node IDs.
+
+## Important Variables/Constants
+
+*   **`MAXLINE`**: Defines a large buffer size (e.g., 64MB) for reading lines from graph files, anticipating potentially very long lines if many adjacencies are on one line.
+*   Format variables (`fmt`, `readew`, `readvw`, `ncon`, `nobj`): Parsed from graph file headers to determine how to read weights.
+
+## Usage Examples
+
+```c
+// In a ParMETIS test program (e.g., parmetis.c):
+// graph_t graph;
+// ParallelReadGraph(&graph, filename, comm); // Reads the input graph
+// ...
+// ParMETIS_V3_PartKway(graph.vtxdist, graph.xadj, ..., part, ...);
+// ...
+// WritePVector(filename, graph.vtxdist, part, comm); // Writes the resulting partition
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` (for `graph_t`, `mesh_t`, `ctrl_t`, `idx_t`, MPI wrappers, GKlib utilities) and likely other common headers for executables.
+    *   `parmetislib.h` (indirectly): Provides `ismalloc`, `imalloc`, `rmalloc`, `gk_cmalloc`, `gk_free`, `MAKECSR`, `icopy`, `strtoidx`, `strtoreal`, `GlobalSESum`, `errexit`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for communication in parallel read/write functions (e.g., `MPI_Bcast`, `MPI_Send`, `MPI_Recv`).
+    *   Standard C library: For file I/O (`fopen`, `fgets`, `sscanf`, `fprintf`, `fclose`), string manipulation (`strlen`).
+*   **Other Interactions**:
+    *   These I/O functions are specific to the driver programs and provide ways to load graphs from disk and save results.
+    *   The `ParallelReadGraph` function's strategy of having one PE (npes-1) read and distribute lines can be a bottleneck for very large files and many PEs. Other approaches (like each PE reading a contiguous block of a pre-split file, or more advanced parallel I/O libraries) are not used here.
+    *   `ReadTestGraph` and `Mc_SerialReadGraph` are simpler: PE 0 reads all, then scatters. This is easier to implement but less scalable.
+
+```

--- a/documentation/kmetis.c.md
+++ b/documentation/kmetis.c.md
@@ -1,0 +1,105 @@
+# libparmetis/kmetis.c
+
+## Overview
+
+This file is the entry point for the core parallel k-way multilevel partitioning algorithm in ParMETIS, specifically `ParMETIS_V3_PartKway`. It orchestrates the entire process of taking a distributed graph and partitioning it into `k` parts. This involves setting up control structures, handling small or trivial graph cases, and invoking the main parallel multilevel partitioning routine (`Global_Partition`).
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_V3_PartKway(idx_t *vtxdist, idx_t *xadj, ..., MPI_Comm *comm)`**:
+    *   This is the main V3 API function for general-purpose parallel k-way graph partitioning.
+    *   **Functionality**:
+        1.  Performs input validation (`CheckInputsPartKway`).
+        2.  Initializes memory management and sets up the `ctrl_t` control structure (`SetupCtrl`).
+        3.  Handles trivial cases:
+            *   If `nparts == 1`, assigns all local vertices to partition 0 (or 1 if `numflag == 1`).
+            *   If `npes == 1` (single processor), it calls the serial METIS `METIS_PartGraphKway` to perform the partitioning.
+        4.  If `numflag > 0` (1-based indexing), converts graph numbering to 0-based (`ChangeNumbering`).
+        5.  Sets up the distributed graph structure (`SetupGraph`).
+        6.  Allocates workspace (`AllocateWSpace`).
+        7.  Sets `ctrl->CoarsenTo`, a threshold for stopping coarsening.
+        8.  Decides whether to partition serially or in parallel:
+            *   If the total number of vertices (`vtxdist[npes]`) is small (less than `SMALLGRAPH` or `npes*20`) or the graph has no edges globally, it calls `PartitionSmallGraph` (which likely assembles the graph and uses serial METIS).
+            *   Otherwise, it calls `Global_Partition` to perform parallel multilevel partitioning.
+        9.  Remaps the graph based on the computed partition (`ParallelReMapGraph`).
+        10. Copies the final partition assignments from `graph->where` to the user's output `part` array.
+        11. Stores the computed edge cut in `*edgecut`.
+        12. Prints timing and statistics if debug flags are set.
+        13. Frees graph structures and control structures.
+        14. If `numflag > 0`, converts numbering back to 1-based.
+        15. Checks for memory leaks.
+*   **`Global_Partition(ctrl_t *ctrl, graph_t *graph)`**:
+    *   This is the core recursive multilevel k-way partitioning algorithm.
+    *   **Functionality (Recursive Multilevel Approach)**:
+        1.  Sets up communication structures for the current graph level (`CommSetup`).
+        2.  **Base Case**: If the global number of vertices (`graph->gnvtxs`) is small enough (e.g., `< 1.3 * ctrl->CoarsenTo`) or the graph is significantly smaller than its finer version (if one exists):
+            *   An initial k-way partition is computed using `InitPartition` (recursive bisection based).
+            *   If it's the original graph (no finer graph, i.e., `graph->finer == NULL`), it applies k-way FM refinement (`KWayFM`).
+        3.  **Recursive Step**: If the graph is large enough:
+            *   Coarsens the graph using `Match_Global` to create `graph->coarser`.
+            *   Optionally writes graph data to disk if `ctrl->ondisk` is set (`graph_WriteToDisk`).
+            *   Recursively calls `Global_Partition` on `graph->coarser`.
+            *   Optionally reads graph data from disk if it was offloaded (`graph_ReadFromDisk`).
+            *   Projects the partition from `graph->coarser` back to the current `graph` (`ProjectPartition`).
+            *   Computes partition parameters (like `lnpwgts`, `gnpwgts`, `mincut`) for the current level using `ComputePartitionParams`.
+            *   If multi-constraint and not too coarse, it may perform k-way balancing (`KWayBalance`) if imbalance is detected.
+            *   Applies k-way FM refinement (`KWayFM`) to improve the projected partition.
+        4.  Prints progress if debug flags are set.
+
+## Important Variables/Constants
+
+*   **`ctrl_t`**: The ParMETIS control structure. Key fields used: `nparts`, `ncon`, `CoarsenTo`, `dbglvl`.
+*   **`graph_t`**: The ParMETIS graph structure, representing the graph at different levels of coarsening.
+*   **`vtxdist`, `xadj`, `adjncy`, `vwgt`, `adjwgt`**: Standard CSR graph representation and weights.
+*   **`part`**: Output array for partition assignments.
+*   **`edgecut`**: Output variable for the number of edges cut.
+*   **`options`**: User-provided options array.
+*   **`SMALLGRAPH`**: Constant from `defs.h` to decide between serial and parallel partitioning for the whole graph.
+*   **`COARSEN_FRACTION`**: Constant from `defs.h` used in the base case condition of `Global_Partition`.
+*   **`NGR_PASSES`**: Constant from `defs.h` for the number of FM refinement passes.
+
+## Usage Examples
+
+```c
+// This file implements the ParMETIS_V3_PartKway API function.
+// Example of calling it:
+// (Assume vtxdist, xadj, adjncy, vwgt, adjwgt, part, comm, etc. are initialized)
+// idx_t ncon = 1, nparts = 4;
+// idx_t options[PARMETIS_MAX_OPTIONS]; options[0] = 0; // Default options
+// idx_t wgtflag = 0; // No weights initially
+// idx_t numflag = 0; // 0-based indexing
+// real_t ubvec[1]; ubvec[0] = 1.05;
+// real_t *tpwgts = NULL; // Equal target partition weights
+// idx_t edgecut_val;
+//
+// ParMETIS_V3_PartKway(vtxdist, xadj, adjncy, vwgt, adjwgt,
+//                      &wgtflag, &numflag, &ncon, &nparts,
+//                      tpwgts, ubvec, options,
+//                      &edgecut_val, part, &comm);
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions.
+    *   `ctrl.c`: For `SetupCtrl`, `FreeCtrl`.
+    *   `graph.c`: For `SetupGraph`, `FreeInitialGraphAndRemap`, `graph_WriteToDisk`, `graph_ReadFromDisk`.
+    *   `wspace.c`: For `AllocateWSpace`, `AllocateRefinementWorkSpace`.
+    *   `comm.c`: For `CheckInputsPartKway`, `GlobalSEMinComm`, `GlobalSESum`, `CommSetup`, etc.
+    *   `initpart.c`: For `InitPartition`.
+    *   `serial.c`: For `PartitionSmallGraph`.
+    *   `remap.c`: For `ParallelReMapGraph`.
+    *   `match.c`: For `Match_Global`.
+    *   `kwayrefine.c`: For `ProjectPartition`, `ComputePartitionParams`, `KWayFM`, `KWayBalance`.
+    *   `util.c`: For `ChangeNumbering`, `ravg`, `rargmax_strd`.
+    *   `metis.h` (external METIS library): For `METIS_PartGraphKway` when `npes == 1`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For all parallel communication.
+    *   `METIS`: Serial METIS library is called as a fallback if `npes == 1`.
+*   **Other Interactions**:
+    *   `ParMETIS_V3_PartKway` is the main entry point for parallel k-way partitioning in ParMETIS when no geometric information is used.
+    *   The `Global_Partition` function implements the classic multilevel paradigm: Coarsen -> Initial Partition (on coarsest) -> Uncoarsen & Refine.
+
+```

--- a/documentation/kwayrefine.c.md
+++ b/documentation/kwayrefine.c.md
@@ -1,0 +1,92 @@
+# libparmetis/kwayrefine.c
+
+## Overview
+
+This file contains core routines for k-way graph partitioning refinement and balancing in ParMETIS. It includes functions to project a partition from a coarser graph to a finer graph, compute essential parameters for refinement (like internal/external degrees and partition weights), and perform k-way refinement using a Fiduccia-Mattheyses (FM)-like approach. It also provides a k-way balancing routine.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ProjectPartition(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Projects a partition from a coarser graph (`graph->coarser`) to the current (finer) `graph`.
+    *   The `graph->match` and `graph->cmap` arrays (computed during coarsening) are used to map coarse graph vertex partitions back to the fine graph vertices.
+    *   Handles communication of partition assignments for vertices whose coarse representation resides on a different processor (`PARMETIS_MTYPE_GLOBAL` matching).
+    *   Frees the coarser graph structure (`graph->coarser`) after projection.
+*   **`ComputePartitionParams(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Computes various parameters essential for refinement after a partition (`graph->where`) is established or projected.
+    *   Initializes `graph->ckrinfo` (stores internal/external degrees and neighbor partition info for each vertex).
+    *   Computes local (`graph->lnpwgts`) and global (`graph->gnpwgts`) partition weights for each constraint.
+    *   Calculates the local (`graph->lmincut`) and global (`graph->mincut`) edge cut.
+    *   Requires communication (`CommInterfaceData`) to get `where` information for ghost vertices.
+*   **`KWayFM(ctrl_t *ctrl, graph_t *graph, idx_t npasses)`**:
+    *   Performs k-way partitioning refinement using an FM-like iterative approach for a specified number of `npasses`.
+    *   Aims to reduce edge cut while respecting balance constraints.
+    *   **Algorithm Steps (per pass, per sub-iteration `c` for side preference)**:
+        1.  Randomly permutes vertices (`perm`) and partitions (`pperm`).
+        2.  Checks current balance (`ComputeParallelBalance`).
+        3.  **Pass 1 (Propose Moves)**: Iterates through vertices. For each eligible border vertex:
+            *   Identifies potential moves to neighboring partitions that improve gain (edge cut reduction) and satisfy balance constraints (`badmaxpwgt`, `IsHBalanceBetterTT`, `IsHBalanceBetterFT`). The `ProperSide` macro influences candidate target partitions.
+            *   If a good move is found, updates `tmp_where` (temporary partition), local/global partition weights (`lnpwgts`, `gnpwgts`, `movewgts`), and internal/external degrees of the moved vertex and its neighbors.
+        4.  Global reduction of `lnpwgts` to get proposed global weights `pgnpwgts`.
+        5.  Computes `overfill` array: if proposed moves lead to imbalance beyond `badmaxpwgt`, calculates how much each partition is overfilled relative to the moves made to it.
+        6.  **Undo Moves (if overweight)**: If `overweight` is detected, iterates through moved vertices and reverts moves that contribute significantly to imbalance (e.g., `overfill > nvwgt[h]/4.0`), updating weights and degrees.
+        7.  **Pass 2 (Commit Moves & Update)**:
+            *   Commits valid moves from `tmp_where` to `graph->where`.
+            *   Identifies vertices whose `ckrinfo` needs updating locally (`update` array) or on other PEs (`supdate` array).
+            *   Communicates changed interface `where` data (`CommChangedInterfaceData`) and lists of vertices needing updates (`rupdate`) to neighbors.
+            *   Updates `ckrinfo` (id, ed, neighbor list) for all vertices in `update` and received in `rupdate`.
+            *   Updates global partition weights `gnpwgts` and `graph->mincut`.
+        8.  If cut doesn't improve, may break early from passes.
+*   **`KWayBalance(ctrl_t *ctrl, graph_t *graph, idx_t npasses)`**:
+    *   A k-way balancing algorithm, structurally similar to `KWayFM` but primarily focused on improving load balance rather than just edge cut.
+    *   It iterates through vertices and considers moves to partitions that improve balance (`IsHBalanceBetterFT`, `IsHBalanceBetterTT`), even if the edge cut gain is not strictly positive.
+    *   It does *not* have the "overfill" check and rollback mechanism present in `KWayFM`. Moves are more greedily applied if they improve balance.
+    *   The selection of moves is also simpler, prioritizing balance improvement.
+    *   Only a fraction of potential moves (e.g., `iii % npes == 0`) might be committed in each sub-iteration to allow for more gradual balancing.
+
+### Macros
+*   **`ProperSide(c, from, other)`**:
+    *   Used in `KWayFM` and `KWayBalance` to guide move selection. `c` (0 or 1) defines a "side" preference based on a permutation of partitions (`pperm`). A move from partition `from` to `other` is considered "proper" if it aligns with the current side preference (e.g., moving from a higher permuted index to a lower one, or vice-versa).
+
+## Important Variables/Constants
+
+*   **`graph->where`**: Array storing the partition assignment for each vertex. Modified by refinement/balancing.
+*   **`graph->match`, `graph->cmap`**: Used by `ProjectPartition`.
+*   **`graph->ckrinfo` (array of `ckrinfo_t`)**: Stores refinement info: `id` (internal degree), `ed` (external degree), `inbr` (index to neighbor list), `nnbrs` (number of distinct neighbor partitions).
+*   **`ctrl->cnbrpool` (array of `cnbr_t`)**: Pool of memory for storing neighbor partition info (`pid`, `ed`).
+*   **`graph->lnpwgts`, `graph->gnpwgts`**: Local and global partition weights.
+*   **`graph->mincut`, `graph->lmincut`**: Global and local edge cut.
+*   **`ctrl->ubvec`, `ctrl->tpwgts`**: Target imbalance and target partition weights.
+*   **`badmaxpwgt`**: Calculated maximum allowed weight for any partition.
+*   **`perm`, `pperm`**: Permutation arrays for randomizing vertex and partition processing.
+*   **`tmp_where`, `moved`, `update`, `supdate`, `rupdate`, `htable`**: Temporary arrays for managing moves and updates during refinement.
+*   `NGR_PASSES`: Default number of passes for KWayFM (from `defs.h`).
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions.
+*   `ProjectPartition` is called during the uncoarsening phase of multilevel algorithms.
+*   `ComputePartitionParams` is called after projection or initial partitioning to prepare for refinement.
+*   `KWayFM` is the primary k-way refinement algorithm used to improve partition quality.
+*   `KWayBalance` is used when load balance is a primary concern and needs to be actively improved.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants, MPI wrappers, memory utilities.
+    *   `graph.c`: `FreeGraph` (for coarser graph), `cnbrpoolGetNext`.
+    *   `comm.c`: `CommInterfaceData`, `CommChangedInterfaceData`, `GlobalSESum`.
+    *   `util.c`: `RandomPermute`, `FastRandomPermute`, `ComputeParallelBalance`, `ravg`, `IsHBalanceBetterTT`, `IsHBalanceBetterFT`.
+    *   `wspace.c`: For workspace allocation.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For communication (`gkMPI_Irecv`, `gkMPI_Isend`, `gkMPI_Wait`, `gkMPI_Waitall`, `gkMPI_Bcast`, `gkMPI_Allreduce`, `gkMPI_Get_count`).
+*   **Other Interactions**:
+    *   These routines iteratively modify `graph->where` and associated partition parameters.
+    *   The effectiveness of refinement depends on the quality of the initial partition and the number of passes.
+    *   `KWayBalance` and `KWayFM` share a lot of structural similarity but differ in their primary objectives (balance vs. cut) and detailed move selection criteria.
+
+```

--- a/documentation/macros.h.md
+++ b/documentation/macros.h.md
@@ -1,0 +1,93 @@
+# libparmetis/macros.h
+
+## Overview
+
+This header file defines a collection of C preprocessor macros used throughout the ParMETIS library. These macros provide convenient shorthands for common operations, including bitwise operations, random number generation (though `HASHFCT` is more of a hashing aid), workspace management for memory, timer operations, and debugging assertions.
+
+## Key Components
+
+### Functions/Classes/Modules/Macros/Structs
+
+This file primarily consists of `#define` directives for macros.
+
+*   **Bitwise Operations**:
+    *   `AND(a, b)`: Computes bitwise AND, handling potential negative `a` by operating on its absolute value.
+    *   `OR(a, b)`: Computes bitwise OR, handling potential negative `a`.
+    *   `XOR(a, b)`: Computes bitwise XOR, handling potential negative `a`.
+    *   *(Note: The handling of negative numbers in these bitwise macros is unusual and might be specific to a particular need or could be problematic if standard two's complement behavior is expected for negative inputs directly in bitwise ops.)*
+
+*   **Hashing Aid**:
+    *   `HASHFCT(key, size)`: Computes `(key) % (size)`, a common way to map a key to an index in a hash table of `size`.
+
+*   **Workspace Core Management (GKlib mcore)**:
+    *   `WCOREPUSH`: Pushes the current state of the memory core/allocator (`ctrl->mcore`). Used to create a new allocation scope.
+    *   `WCOREPOP`: Pops the memory core state, effectively freeing memory allocated since the corresponding `WCOREPUSH`.
+    *   *(These rely on `ctrl->mcore` being a valid `gk_mcore_t*` from GKlib.)*
+
+*   **Timer Macros**:
+    *   `cleartimer(tmr)`: Sets timer `tmr` to `0.0`.
+    *   `starttimer(tmr)`: Starts/resumes a timer by subtracting the current `MPI_Wtime()`.
+    *   `stoptimer(tmr)`: Stops/pauses a timer by adding the current `MPI_Wtime()`. The duration is `tmr_after_stop - tmr_after_start`.
+    *   `gettimer(tmr)`: Returns the current value of timer `tmr`.
+    *   `STARTTIMER(ctrl, tmr)`: A wrapper that, if `DBG_TIME` is set in `ctrl->dbglvl`, optionally barriers and then calls `starttimer(tmr)`.
+    *   `STOPTIMER(ctrl, tmr)`: A wrapper that, if `DBG_TIME` is set, optionally barriers and then calls `stoptimer(tmr)`.
+
+*   **Debugging Assertion Macros**:
+    *   `PASSERT(ctrl, expr)`: If `NDEBUG` is not defined, this macro checks if `expr` is true. If false, it prints an assertion failure message (including file and line number, and the expression itself) using `myprintf` (a ParMETIS utility, likely printing from PE 0) and then calls `assert(expr)` which would typically terminate the program. If `NDEBUG` is defined, the assertion is compiled out to nothing.
+    *   `PASSERTP(ctrl, expr, msg)`: Similar to `PASSERT`, but allows for an additional custom message `msg` (which should be in `myprintf` format, e.g., `(ctrl, "Value was %d", val)`) to be printed upon assertion failure.
+
+*   **Boundary List Macros (for vertex boundary management)**:
+    *   `BNDInsert(nbnd, bndind, bndptr, vtx)`: Inserts vertex `vtx` into a boundary list.
+        *   `bndind`: An array storing the vertex indices in the boundary list.
+        *   `bndptr`: An array mapping a vertex index to its position in `bndind`.
+        *   `nbnd`: The current number of elements in the boundary list (incremented by the macro).
+    *   `BNDDelete(nbnd, bndind, bndptr, vtx)`: Deletes vertex `vtx` from a boundary list. It does this by swapping the target vertex with the last vertex in `bndind`, decrementing `nbnd`, and updating `bndptr`.
+
+## Important Variables/Constants
+
+*   `ctrl->mcore`: Used by `WCOREPUSH`/`WCOREPOP`, expected to be a GKlib memory core object.
+*   `ctrl->dbglvl`: Used by `STARTTIMER`/`STOPTIMER` and assertion macros to control behavior.
+*   `DBG_TIME`: A debug flag constant (defined in `defs.h` or `parmetis.h`).
+*   `NDEBUG`: Standard C preprocessor macro; if defined, assertions are disabled.
+
+## Usage Examples
+
+```c
+// Timer usage:
+// cleartimer(ctrl->SomeTimer);
+// STARTTIMER(ctrl, ctrl->SomeTimer);
+// /* ... code to time ... */
+// STOPTIMER(ctrl, ctrl->SomeTimer);
+// printf("Time taken: %f\n", gettimer(ctrl->SomeTimer));
+
+// Assertion usage:
+// PASSERT(ctrl, nvtxs > 0);
+// PASSERTP(ctrl, balance[0] < 1.5, (ctrl, "Imbalance too high: %.2f", balance[0]));
+
+// Workspace usage:
+// WCOREPUSH;
+// my_temp_array = iwspacemalloc(ctrl, 100);
+// /* ... use my_temp_array ... */
+// WCOREPOP; // my_temp_array is effectively freed here
+
+// Boundary list (conceptual):
+// idx_t nbnd = 0, *bndind, *bndptr;
+// /* ... allocate bndind and bndptr ... */
+// BNDInsert(nbnd, bndind, bndptr, new_boundary_vertex);
+// BNDDelete(nbnd, bndind, bndptr, old_boundary_vertex);
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Likely includes this file. It would provide `ctrl_t`, `idx_t`, `myprintf`, MPI wrappers (`gkMPI_Barrier`, `MPI_Wtime`), and GKlib memory core types/functions if `WCOREPUSH`/`POP` are used with GKlib's `gk_mcore`.
+    *   `defs.h` or `parmetis.h`: For debug flag constants like `DBG_TIME`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: `MPI_Wtime()` is used by the timer macros. `gkMPI_Barrier` is also used.
+    *   Standard C `assert.h`: For the `assert()` call within `PASSERT`/`PASSERTP`.
+*   **Other Interactions**:
+    *   The assertion macros are critical for debugging and ensuring preconditions or invariants hold during execution. They are typically compiled out in release builds (when `NDEBUG` is defined) to avoid performance overhead.
+    *   Timer macros help in performance profiling.
+    *   Workspace macros simplify scoped memory allocation if using GKlib's mcore facility.
+
+```

--- a/documentation/match.c.md
+++ b/documentation/match.c.md
@@ -1,0 +1,103 @@
+# libparmetis/match.c
+
+## Overview
+
+This file implements graph matching algorithms, which are crucial for the coarsening phase of multilevel graph partitioning. It provides two main matching strategies: `Match_Global` for matching that can span across processors, and `Match_Local` for matching restricted to vertices within the same processor (based on their `home` or `where` info). The goal of matching is to select pairs of vertices (or groups) that will be merged to form the vertices of the next coarser graph.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`Match_Global0(ctrl_t *ctrl, graph_t *graph)`**:
+    *   (Older version, possibly for comparison or specific internal use, as `Match_Global` seems to be the primary one called elsewhere like `kmetis.c`).
+    *   Finds a Heavy Edge Matching (HEM) that can involve both local and remote vertices.
+    *   Iterates `NMATCH_PASSES`. In each pass:
+        *   Processes unmatched vertices in a permuted order.
+        *   For each vertex `i`, it tries to find a suitable match `k` (local or remote) that maximizes edge weight, considering `myhome[i] == myhome[k]` (vertices should belong to the same original partition/PE for some schemes).
+        *   Local matches are granted immediately.
+        *   Remote match requests are sent to the target PE. Target PEs grant requests if their vertex is unmatched, with some logic (`nkept`) to balance who "keeps" the matched pair for the coarse graph.
+        *   Two-hop matching is considered in the last pass if `ctrl->twohop` is set and local matching fails.
+    *   Vertices that remain unmatched are matched with themselves (they carry over to the coarser graph).
+    *   Sets `graph->match_type = PARMETIS_MTYPE_GLOBAL`.
+    *   Calls `CreateCoarseGraph_Global` and optionally `DropEdges`.
+*   **`Match_Global(ctrl_t *ctrl, graph_t *graph)`**:
+    *   This appears to be the primary global matching function. Structurally very similar to `Match_Global0`.
+    *   It performs multiple passes (`NMATCH_PASSES`) of attempting to match vertices.
+    *   **Matching Logic (per pass)**:
+        1.  Vertices are processed in a random order (`perm`).
+        2.  Vertices marked `TOO_HEAVY` (normalized weight `nvwgt > maxnvwgt`) are not matched.
+        3.  For an unmatched vertex `i`:
+            *   If it's an island (no edges), it tries to match with another local island vertex.
+            *   Otherwise, it seeks a heavy-edge match `k` where `myhome[i] == myhome[k]`. Preference is given to heavier edges, and for multi-constraint, `BetterVBalance` is used as a tie-breaker.
+            *   If `k` is local, the match `(i, k)` is made.
+            *   If `k` is remote, `i` is marked `MAYBE_MATCHED`, and a request is sent to the PE owning `k`. A "wside" logic (alternating preference based on global vertex ID) determines which PE initiates the request.
+        4.  **Request Resolution**: MPI communication exchanges match requests. A PE receiving a request grants it if its local vertex is available. A heuristic (`nkept`) attempts to balance which PE gets to "keep" the resulting coarse vertex.
+        5.  Granted matches are communicated back, and local `match` arrays are updated.
+        6.  A final two-hop matching pass (`ctrl->twohop`) can be performed to match remaining vertices by looking at neighbors of neighbors (only if the intermediate vertex is local, based on the `Match_Global0` two-hop logic, though `Match_Global`'s two-hop part is more complex and involves creating a temporary transpose adjacency).
+    *   Unmatched or `TOO_HEAVY` vertices are matched with themselves.
+    *   Calls `CreateCoarseGraph_Global` and optionally `DropEdges`.
+*   **`Match_Local(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Finds a Heavy Edge Matching (HEM) involving only local vertices.
+    *   Vertices are matched only if `myhome[vertex1] == myhome[vertex2]` and both are local.
+    *   Heavy vertices (weight `> maxnvwgt`) are not matched.
+    *   Iterates through permuted local vertices. If a vertex `i` is unmatched and not too heavy, it finds the best local match `k` (also not too heavy) based on edge weight and (for multi-constraint) `BetterVBalance`.
+    *   Matched pairs are recorded in `graph->match`. Unmatched vertices are matched with themselves.
+    *   Sets `graph->match_type = PARMETIS_MTYPE_LOCAL`.
+    *   Calls `CreateCoarseGraph_Local`.
+*   **`CreateCoarseGraph_Global(ctrl_t *ctrl, graph_t *graph, idx_t cnvtxs)`**:
+    *   Constructs the coarser graph (`cgraph`) based on the `match` array from `Match_Global`.
+    *   Calculates `cgraph->vtxdist` (coarse graph vertex distribution).
+    *   Populates `graph->cmap` which maps fine vertices to coarse vertices. This involves communication for remote matches.
+    *   Exchanges adjacency lists of fine vertices that are matched with remote vertices. `scand`/`rcand` and `sgraph`/`rgraph` are used to manage this data transfer.
+    *   Collapses matched fine vertices into coarse vertices:
+        *   Sums vertex weights (`cvwgt`, `cvsize`).
+        *   Sets `chome` for the coarse vertex (usually from the "keeper" of the match).
+        *   Merges adjacency lists, summing edge weights for common neighbors, using a hash table (`htable`) to detect common neighbors efficiently.
+    *   Initializes `cgraph->nvwgt`.
+*   **`CreateCoarseGraph_Local(ctrl_t *ctrl, graph_t *graph, idx_t cnvtxs)`**:
+    *   Constructs the coarser graph based on a local matching.
+    *   Similar to `CreateCoarseGraph_Global` but simpler as all matches are local.
+    *   Calculates `cgraph->vtxdist`.
+    *   Constructs `graph->cmap` (local operation, then `CommInterfaceData` to share with neighbors).
+    *   Collapses locally matched fine vertices into coarse vertices, summing weights and merging adjacency lists using a hash table.
+*   **`DropEdges(ctrl_t *ctrl, graph_t *graph)`**:
+    *   (Optional, if `ctrl->dropedges` is set) A heuristic to reduce the number of edges in the coarser graph.
+    *   For each vertex, it determines a median weight of its incident edges (considering some random noise).
+    *   Edges with weight less than the minimum of the median weights of their endpoints are dropped.
+    *   This aims to remove less significant edges to speed up coarsening and potentially improve quality. Requires `CommSetup` on the coarse graph first.
+
+## Important Variables/Constants
+
+*   **`graph->match`**: Array storing matching information. `match[i] = global_idx_of_partner + KEEP_BIT` if local PE keeps the coarse vertex, or `global_idx_of_partner` if remote PE keeps it. `UNMATCHED`, `MAYBE_MATCHED`, `TOO_HEAVY` are special states.
+*   **`graph->cmap`**: Maps fine graph vertex indices to coarse graph vertex indices.
+*   **`graph->home` / `myhome`**: Array indicating the original partition/PE of vertices, used to guide matching (e.g., match only within the same home).
+*   **`maxnvwgt`**: Threshold for marking vertices as `TOO_HEAVY`. `0.75 / ctrl->CoarsenTo`.
+*   **`NMATCH_PASSES`**: Number of matching iterations.
+*   **`KEEP_BIT`**: A bit flag (e.g., `1<<30`) added to `match[i]` to indicate that the current PE is responsible for the coarse vertex formed by this match.
+*   `htable` (in CreateCoarseGraph*): Hash table used for efficient merging of adjacency lists.
+*   `LHTSIZE`, `MASK`: Constants for the local hash table in `CreateCoarseGraph_Local`.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions used within the multilevel coarsening process (e.g., called by `Global_Partition` in `kmetis.c` or `Adaptive_Partition` in `ametis.c`).
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants.
+    *   `graph.c`: For `CreateGraph`, `FreeCommSetupFields`.
+    *   `comm.c`: For `CommInterfaceData`, `CommChangedInterfaceData`, `CommSetup`.
+    *   `util.c`: For `FastRandomPermute`, `RandomPermute`, `RandomInRange`, `BetterVBalance`.
+    *   `wspace.c`: For workspace allocation.
+    *   `gklib.c` (indirectly): For GKlib utilities like `icopy`, `iset`, `imalloc`, `ikvsorti`, `isortd`, `isum`, `gk_max`, `gk_min`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For all inter-processor communication during global matching and coarse graph construction.
+*   **Other Interactions**:
+    *   The output of these matching functions (`graph->match`, `graph->cmap`) and the resulting coarse graph (`graph->coarser`) are fundamental inputs to the next level of the multilevel algorithm.
+    *   The `ctrl->partType` (STATIC, ADAPTIVE, ORDER) influences how `home` information is used.
+    *   `ctrl->twohop` and `ctrl->dropedges` enable optional heuristics.
+
+```

--- a/documentation/mdiffusion.c.md
+++ b/documentation/mdiffusion.c.md
@@ -1,0 +1,82 @@
+# libparmetis/mdiffusion.c
+
+## Overview
+
+This file implements multi-constraint diffusion (Mc_Diffusion) and related utilities for load balancing in ParMETIS. Diffusion algorithms attempt to balance workload by modeling the flow of work between partitions, often by solving a system of linear equations. This file includes functions to set up the problem (e.g., graph of partition connectivity, load vectors), solve it using Conjugate Gradient, and then apply the solution to move vertices or adjust partition assignments. It also contains a specific routine `BalanceMyLink` (though a more prominent version exists in `balancemylink.c`) and `RedoMyLink` which seem to be local refinement/balancing operations between two specific partitions.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`Mc_Diffusion(ctrl_t *ctrl, graph_t *graph, idx_t *vtxdist, idx_t *where, idx_t *home, idx_t npasses)`**:
+    *   The main multi-constraint diffusion function.
+    *   It iterates for `npasses` or until balance is achieved.
+    *   In each pass:
+        1.  Constructs a "connectivity graph" of partitions (`matrix`) using `SetUpConnectGraph`.
+        2.  For each constraint `h`:
+            *   Computes current load imbalance (`ComputeLoad`).
+            *   Solves a linear system `Ax = b` using `ConjGrad2`, where `A` is the partition connectivity matrix and `b` is the load imbalance. The solution `x` represents "potentials" or "pressures".
+            *   Computes `transfer` amounts along edges of the partition graph based on `x` (`ComputeTransferVector`).
+        3.  Identifies independent sets of inter-partition links (edges in `matrix`) to process in parallel using `CSR_Match_SHEM`.
+        4.  For each matched pair of partitions (`me`, `you`) assigned to the current PE:
+            *   Extracts the subgraph `egraph` consisting of vertices in `me` or `you` (`ExtractGraph`).
+            *   Calls `RedoMyLink` and/or `BalanceMyLink` (a local 2-way refinement/balancing function) on `egraph` to adjust vertex assignments between `me` and `you` based on the computed `diff_flows` (derived from `transfer`).
+            *   The choice between `RedoMyLink` and `BalanceMyLink` results might depend on balance and cost.
+        5.  Communicates updated `where` information for moved vertices.
+        6.  Optionally performs serial k-way refinement (`Mc_SerialKWayAdaptRefine`) on the entire graph (assembled locally, though this part is not fully shown in `Mc_Diffusion` but implied by usage pattern in other files).
+        7.  Checks for convergence based on overall balance (`lbavg`) or if no swaps occurred.
+*   **`SetUpConnectGraph(graph_t *graph, matrix_t *matrix, idx_t *workspace)`**:
+    *   (Duplicate of the one in `diffutil.c`) Builds a coarse matrix representing connectivity between current partitions in `graph->where`.
+*   **`Mc_ComputeMoveStatistics(ctrl_t *ctrl, graph_t *graph, idx_t *nmoved, idx_t *maxin, idx_t *maxout)`**:
+    *   (Duplicate of the one in `diffutil.c`) Computes statistics about vertex movements.
+*   **`Mc_ComputeSerialTotalV(graph_t *graph, idx_t *home)`**:
+    *   (Duplicate of the one in `diffutil.c`) Computes total weight of vertices not in their home partition.
+*   **`ComputeLoad(graph_t *graph, idx_t nparts, real_t *load, real_t *tpwgts, idx_t index)`**:
+    *   (Duplicate of the one in `diffutil.c`) Computes load imbalance for a specific constraint.
+*   **`ConjGrad2(matrix_t *A, real_t *b, real_t *x, real_t tol, real_t *workspace)`**:
+    *   (Duplicate of the one in `diffutil.c`) Conjugate Gradient solver.
+*   **`mvMult2(matrix_t *A, real_t *v, real_t *w)`**:
+    *   (Duplicate of the one in `diffutil.c`) Matrix-vector multiplication.
+*   **`ComputeTransferVector(idx_t ncon, matrix_t *matrix, real_t *solution, real_t *transfer, idx_t index)`**:
+    *   (Duplicate of the one in `diffutil.c`) Computes transfer amounts from solution potentials.
+*   **`ExtractGraph(ctrl_t *ctrl, graph_t *graph, idx_t *indicator, idx_t *map, idx_t *rmap)`**:
+    *   Extracts a subgraph containing only vertices marked by the `indicator` array.
+    *   `map` stores the original indices of the extracted vertices, `rmap` maps original indices to extracted indices.
+    *   Used in `Mc_Diffusion` to create a temporary graph for `BalanceMyLink`/`RedoMyLink`.
+
+## Important Variables/Constants
+
+*   **`matrix_t matrix`**: Represents the graph of connections between partitions.
+*   **`transfer`**: Array storing flow amounts computed for edges in `matrix`.
+*   **`solution`, `load`**: Vectors used in the CG solver for potentials and load imbalances.
+*   **`egraph`**: Temporary graph structure for vertices in two partitions being balanced.
+*   **`diff_flows`, `sr_flows`**: Flow values passed to `BalanceMyLink` and `RedoMyLink`.
+*   `N_MOC_GD_PASSES` (from `defs.h`): Likely related to number of global diffusion passes, though `npasses` is passed to `Mc_Diffusion`.
+*   `NGD_PASSES` (from `defs.h`): Maximum iterations for the inner loop of `Mc_Diffusion`.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions. `Mc_Diffusion` is a load-balancing algorithm that might be called during adaptive repartitioning (`ametis.c`) or as part of an initial balancing phase (`initbalance.c`).
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants.
+    *   `diffutil.c`: This file duplicates several functions from `diffutil.c`. Ideally, these would be shared.
+    *   `csrmatch.c`: `CSR_Match_SHEM` is used to find independent sets of inter-partition links.
+    *   `balancemylink.c`: Contains `BalanceMyLink`.
+    *   `redomylink.c`: Contains `RedoMyLink`.
+    *   `kwayrefine.c` (indirectly): `Mc_SerialKWayAdaptRefine` is called.
+    *   `graph.c`: For `CreateGraph`, `ExtractGraph` uses `CreateGraph`, `MAKECSR`.
+    *   `GKlib` utilities: For memory allocation, array operations.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for communication (`gkMPI_Allgatherv`, `gkMPI_Allreduce`, `GlobalSESum`).
+*   **Other Interactions**:
+    *   `Mc_Diffusion` modifies the `graph->where` array to balance loads.
+    *   The effectiveness depends on the CG solver's convergence and the heuristics in `BalanceMyLink`/`RedoMyLink`.
+    *   The duplication of several utility functions also found in `diffutil.c` is notable and could be a point of refactoring.
+
+```

--- a/documentation/mesh.c.md
+++ b/documentation/mesh.c.md
@@ -1,0 +1,92 @@
+# libparmetis/mesh.c
+
+## Overview
+
+This file contains the implementation of `ParMETIS_V3_Mesh2Dual`, a ParMETIS API function. Its purpose is to convert a distributed mesh (defined by elements and their constituent nodes) into its dual graph. In the dual graph, each mesh element becomes a vertex, and an edge connects two dual graph vertices if their corresponding mesh elements share a common face (defined by `ncommon` common nodes).
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_V3_Mesh2Dual(idx_t *elmdist, idx_t *eptr, idx_t *eind, idx_t *numflag, idx_t *ncommon, idx_t **r_xadj, idx_t **r_adjncy, MPI_Comm *comm)`**:
+    *   This is the V3 API function for mesh-to-dual conversion.
+    *   **Parameters**:
+        *   `elmdist`: Distribution of elements among processors.
+        *   `eptr`: CSR-like pointer array for `eind`, indicating nodes per element.
+        *   `eind`: Array storing node IDs for each element.
+        *   `numflag`: Indicates 0-based or 1-based numbering for input `eind`.
+        *   `ncommon`: The number of common nodes required to define a shared face (e.g., 2 for 2D triangles/quads, 3 for 3D tetrahedra, 4 for 3D hexahedra if faces are quads).
+        *   `r_xadj` (output): Pointer to store the `xadj` (adjacency pointers) of the resulting dual graph.
+        *   `r_adjncy` (output): Pointer to store the `adjncy` (adjacency list) of the resulting dual graph.
+        *   `comm`: MPI communicator.
+    *   **Functionality**:
+        1.  Handles `numflag` for initial node renumbering if input is 1-based (`ChangeNumberingMesh`).
+        2.  Normalizes global node IDs by subtracting the global minimum node ID.
+        3.  Constructs a global node distribution (`nodedist`).
+        4.  **Local Renumbering & Node-to-Element List Construction (Pass 1 - Local)**:
+            *   Each PE creates a local mapping of its unique nodes (`nmap`).
+            *   `eind` is updated with these local node IDs.
+            *   A `nodelist` (array of `ikv_t`) is created where `key` is global node ID and `val` is the local element ID using that node.
+        5.  **Global Node-to-Element List (Pass 2 - Communication)**:
+            *   `nodelist` entries are sent to PEs that own the respective global nodes (`gkMPI_Alltoallv`).
+            *   Each PE constructs `gnptr`, `gnind`: a list of elements for each of its assigned global nodes.
+        6.  **Element Adjacency Information Exchange (Pass 3 - Communication)**:
+            *   Each PE determines which other PEs need its `gnind` lists (based on which PEs have elements using its nodes).
+            *   The `gnind` lists (elements incident to a node) are sent to those PEs (`gkMPI_Alltoallv`).
+            *   Each PE receives lists of elements for nodes that are part of its local elements. This forms `nptr`, `nind` (local view of node-to-global-element list for relevant nodes).
+        7.  **Dual Graph Construction (Pass 4 & 5 - Local)**:
+            *   Iterates through local elements. For each element `i`:
+                *   For each node in element `i`:
+                    *   Iterates through other elements `kk` sharing that node (from `nptr`, `nind`).
+                    *   A hash table (`htable`) is used to count common nodes between element `i` and element `kk`.
+                *   If the count of common nodes for an adjacent element `kk` is `>= *ncommon`, an edge is added in the dual graph between element `i` and element `kk`.
+            *   This is done in two passes: first to count degrees (for `myxadj`), then to fill `myadjncy`.
+        8.  The output `*r_xadj` and `*r_adjncy` are populated with the CSR structure of the dual graph.
+        9.  Node numbering in `eind` is restored to original global values + `gminnode`.
+        10. If `numflag` was 1, dual graph numbering is also adjusted back.
+
+## Important Variables/Constants
+
+*   **`elmdist`**: Distribution of elements.
+*   **`eptr`, `eind`**: Input mesh connectivity (elements to nodes).
+*   **`ncommon`**: Number of common nodes to define an edge in the dual graph.
+*   **`nodedist`**: Calculated distribution of global nodes among PEs.
+*   **`nodelist (ikv_t *)`**: Temporary list mapping global node IDs to local element IDs.
+*   **`gnptr`, `gnind`**: CSR-like list on each PE: for each of its nodes, lists all global elements incident to it.
+*   **`nptr`, `nind`**: CSR-like list on each PE: for each local unique node in its elements, lists all global elements incident to it (received from other PEs).
+*   **`htable`**: Hash table used during dual graph construction to count shared nodes between elements.
+*   **`myxadj`, `myadjncy`**: Output CSR arrays for the dual graph.
+*   `mask`: Used for hashing, `(1<<11)-1`.
+
+## Usage Examples
+
+```c
+// Conceptual call to ParMETIS_V3_Mesh2Dual
+// (assuming elmdist, eptr, eind, comm are set up)
+// idx_t numflag = 0;
+// idx_t ncommonnodes = 3; // For 3D tetrahedra, for example
+// idx_t *xadj_dual, *adjncy_dual;
+//
+// ParMETIS_V3_Mesh2Dual(elmdist, eptr, eind, &numflag, &ncommonnodes,
+//                       &xadj_dual, &adjncy_dual, &comm);
+//
+// // xadj_dual and adjncy_dual now represent the dual graph
+// // where elmdist can be used as its vtxdist.
+// // Need to free xadj_dual and adjncy_dual later using METIS_Free.
+```
+This is an API function.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `idx_t`, `ikv_t`, MPI wrappers, memory utilities (`ismalloc`, `ikvmalloc`, `imalloc`, `irealloc`, `gk_free`, `gk_malloc_init`, `gk_GetCurMemoryUsed`, `gk_malloc_cleanup`), sorting (`ikvsorti`), math ops (`imin`, `imax`).
+    *   `util.c`: `ChangeNumberingMesh`.
+    *   `comm.c`: `GlobalSEMinComm`, `GlobalSEMaxComm`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used extensively for communication (`gkMPI_Comm_size`, `gkMPI_Comm_rank`, `gkMPI_Alltoall`, `gkMPI_Alltoallv`, `gkMPI_Barrier`, `gkMPI_Allreduce`).
+*   **Other Interactions**:
+    *   The output dual graph (`*r_xadj`, `*r_adjncy`) uses `elmdist` as its vertex distribution. Each element of the original mesh becomes a vertex in the dual graph.
+    *   The user is responsible for freeing the allocated `*r_xadj` and `*r_adjncy` using `METIS_Free` (as ParMETIS uses `malloc` for these outputs, aligning with METIS conventions for graph structures returned by API calls).
+    *   The efficiency of the hash table (`htable` with fixed size `mask+1`) might be a factor for meshes with very high node degrees in the dual (i.e., elements connected to many other elements via shared nodes, though this is less common for typical mesh duals).
+
+```

--- a/documentation/mmetis.c.md
+++ b/documentation/mmetis.c.md
@@ -1,0 +1,82 @@
+# libparmetis/mmetis.c
+
+## Overview
+
+This file serves as the entry point for `ParMETIS_V3_PartMeshKway`, a ParMETIS API function designed for partitioning a distributed mesh into `k` parts. It achieves this by first converting the mesh into its dual graph representation and then partitioning this dual graph using the standard parallel k-way graph partitioning algorithm (`ParMETIS_V3_PartKway`).
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_V3_PartMeshKway(idx_t *elmdist, idx_t *eptr, idx_t *eind, idx_t *elmwgt, idx_t *wgtflag, idx_t *numflag, idx_t *ncon, idx_t *ncommon, idx_t *nparts, real_t *tpwgts, real_t *ubvec, idx_t *options, idx_t *edgecut, idx_t *part, MPI_Comm *comm)`**:
+    *   This is the V3 API function for k-way partitioning of a distributed mesh.
+    *   **Parameters**:
+        *   `elmdist`: Distribution of mesh elements among processors.
+        *   `eptr`, `eind`: CSR-like representation of the mesh (elements to nodes).
+        *   `elmwgt`: Weights of the mesh elements (if `wgtflag` indicates).
+        *   `wgtflag`: Flags for presence of element weights.
+        *   `numflag`: 0-based or 1-based indexing for input `eind`.
+        *   `ncon`: Number of constraints for element weights.
+        *   `ncommon`: Number of common nodes defining a shared face (for dual graph construction).
+        *   `nparts`: Desired number of partitions.
+        *   `tpwgts`: Target partition weights.
+        *   `ubvec`: Load imbalance tolerance.
+        *   `options`: ParMETIS options array.
+        *   `edgecut` (output): Stores the edge cut of the partition on the dual graph.
+        *   `part` (output): Stores the partition assignment for each local element.
+        *   `comm`: MPI communicator.
+    *   **Functionality**:
+        1.  Performs input validation (`CheckInputsPartMeshKway`).
+        2.  Initializes memory management and sets up a minimal `ctrl_t` structure (primarily for communicator and debug level).
+        3.  **Mesh to Dual Conversion**: Calls `ParMETIS_V3_Mesh2Dual` to convert the input mesh into its dual graph. The dual graph's adjacency structure is returned in `xadj` and `adjncy`. The vertices of the dual graph correspond to the elements of the original mesh, so `elmdist` serves as the `vtxdist` for the dual graph, and `elmwgt` serves as its `vwgt`.
+        4.  **Dual Graph Partitioning**: Calls `ParMETIS_V3_PartKway` to partition the newly created dual graph. The parameters `elmdist` (as `vtxdist`), `xadj`, `adjncy`, `elmwgt` (as `vwgt`), `wgtflag`, `numflag`, `ncon`, `nparts`, `tpwgts`, `ubvec`, `options` are passed to this function. The resulting partition for the dual graph vertices (which are the mesh elements) is stored in `part`, and the edge cut is stored in `edgecut`.
+        5.  Frees the dynamically allocated `xadj` and `adjncy` for the dual graph using `METIS_Free`.
+        6.  Frees the control structure and performs memory cleanup.
+
+## Important Variables/Constants
+
+*   **`elmdist`, `eptr`, `eind`, `elmwgt`**: Input mesh data.
+*   **`ncommon`**: Parameter for `ParMETIS_V3_Mesh2Dual`.
+*   **`xadj`, `adjncy`**: Temporary pointers to store the CSR structure of the dual graph.
+*   **`part`, `edgecut`**: Output parameters.
+
+## Usage Examples
+
+```c
+// Conceptual call to ParMETIS_V3_PartMeshKway
+// (assuming elmdist, eptr, eind, elmwgt, part, comm, etc. are set up)
+// idx_t wgtflag = 1; // Assume element weights are provided
+// idx_t numflag = 0;
+// idx_t ncon = 1;
+// idx_t ncommonnodes = 3; // e.g., for 3D tet mesh
+// idx_t nparts_val = 4;
+// real_t ubvec_val[1]; ubvec_val[0] = 1.05;
+// idx_t options_val[PARMETIS_MAX_OPTIONS]; options_val[0] = 0;
+// idx_t edgecut_val;
+//
+// ParMETIS_V3_PartMeshKway(elmdist, eptr, eind, elmwgt,
+//                          &wgtflag, &numflag, &ncon, &ncommonnodes, &nparts_val,
+//                          NULL, ubvec_val, options_val,
+//                          &edgecut_val, part, &comm);
+//
+// // 'part' now contains the partition for each local element.
+// // 'edgecut_val' is the cut on the dual graph.
+```
+This is an API function.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions.
+    *   `ctrl.c`: For `SetupCtrl`, `FreeCtrl`.
+    *   `comm.c`: For `CheckInputsPartMeshKway`, `GlobalSEMinComm`, `GlobalSESum`.
+    *   `mesh.c`: `ParMETIS_V3_Mesh2Dual` is called to perform the mesh-to-dual conversion.
+    *   `kmetis.c`: `ParMETIS_V3_PartKway` is called to partition the generated dual graph.
+    *   `metis.h` (external METIS library): `METIS_Free` is used to deallocate the dual graph structure.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used by underlying functions.
+*   **Other Interactions**:
+    *   This function provides a convenient way to partition a mesh by leveraging graph partitioning algorithms on its dual. The quality of the mesh partition depends on how well the dual graph representation captures the connectivity and balance requirements of the original mesh.
+    *   The `elmwgt` (element weights) become the `vwgt` (vertex weights) for the dual graph partitioning.
+
+```

--- a/documentation/move.c.md
+++ b/documentation/move.c.md
@@ -1,0 +1,70 @@
+# libparmetis/move.c
+
+## Overview
+
+This file contains functions related to redistributing a ParMETIS graph (`graph_t`) according to a new partition, and projecting information (like partition assignments) back from a redistributed (moved) graph to the original graph's distribution. These are key operations in parallel graph partitioning, especially when an algorithm computes a new partition on a graph that might have a different distribution than the original input, or when the graph data itself needs to be moved to match a new partition.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`MoveGraph(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Redistributes the input `graph` data across processors according to the current partition assignments stored in `graph->where`.
+    *   It assumes `ctrl->nparts` (number of target partitions in `graph->where`) is less than or equal to `ctrl->npes` (number of processors), implying each target partition will reside on at most one processor.
+    *   **Steps**:
+        1.  Calculates `mvtxdist`: the vertex distribution of the new "moved" graph (`mgraph`). Each PE `p` will own vertices assigned to partition `p`.
+        2.  Determines `newlabel` for each local vertex: its new global index in `mgraph`. This involves a parallel prefix scan (`gkMPI_Scan`) on the counts of vertices going to each PE.
+        3.  Communicates `newlabel` for interface vertices (`CommInterfaceData`).
+        4.  Each PE determines how many vertices and edges it's sending to every other PE (`sinfo`) and how many it's receiving (`rinfo`) using `gkMPI_Alltoall`.
+        5.  Graph data (CSR structure, vertex weights) is packed into `sgraph` and sent to target PEs using non-blocking sends/receives (`gkMPI_Isend`, `gkMPI_Irecv`, `gkMPI_Waitall`). Adjacency lists in `sgraph` use the `newlabel` for adjacencies.
+        6.  A new graph `mgraph` is created on each PE from the received data (`rgraph`). `mgraph->vtxdist` is set to `mvtxdist`.
+    *   Returns the new `mgraph`.
+*   **`ProjectInfoBack(ctrl_t *ctrl, graph_t *graph, idx_t *info, idx_t *minfo)`**:
+    *   Transfers information from an array `minfo` (which is distributed according to a "moved" graph, likely the result of `MoveGraph` or a similar operation) back to an array `info` that corresponds to the original distribution of `graph`.
+    *   `graph->where` is assumed to hold the `npes`-way partition that describes how `graph` was moved to create the graph associated with `minfo`.
+    *   **Steps**:
+        1.  Each PE determines how many elements of `minfo` it needs to send to other PEs based on `graph->where` (which indicates the original PE of the vertices that were moved to the current PE).
+        2.  Uses `gkMPI_Alltoall` to communicate these counts.
+        3.  Uses non-blocking sends/receives to transfer relevant portions of `minfo` to the PEs that need them (those PEs are the original owners of the vertices).
+        4.  Received data is scattered into the `info` array according to `graph->where`.
+*   **`FindVtxPerm(ctrl_t *ctrl, graph_t *graph, idx_t *perm)`**:
+    *   Computes a permutation array `perm` based on the current partition assignments in `graph->where`.
+    *   The permutation orders vertices by their partition ID, and within each partition, by their original relative order on their source PE.
+    *   This is useful for reordering vertex data to be contiguous by partition.
+    *   Uses `gkMPI_Scan` and `gkMPI_Allreduce` to determine global offsets for each partition.
+*   **`CheckMGraph(ctrl_t *ctrl, graph_t *graph)`**:
+    *   A debugging function to check the consistency of a moved graph.
+    *   It verifies that if vertex `u` (local to current PE) has an edge to local vertex `v`, then `v` also has an edge back to `u`.
+    *   Prints error messages if inconsistencies are found.
+
+## Important Variables/Constants
+
+*   **`graph->where`**: Array storing the partition assignment for each vertex. Crucial for both `MoveGraph` (determines destination PE) and `ProjectInfoBack` (determines source PE of data).
+*   **`newlabel` (in `MoveGraph`)**: Temporary array storing the new global indices of vertices after re-distribution.
+*   **`mvtxdist` (in `MoveGraph`)**: The `vtxdist` for the newly created `mgraph`.
+*   **`sinfo`, `rinfo` (in `MoveGraph`, `ProjectInfoBack`)**: Arrays of `ikv_t` (or similar) used to store counts of vertices/edges/data being sent/received between PEs.
+*   **`sgraph`, `rgraph` (in `MoveGraph`)**: Buffers for sending and receiving graph data during redistribution.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions.
+*   `MoveGraph` is used when a partitioning algorithm has determined a new distribution of the graph across processors (e.g., after an initial geometric partition in `gkmetis.c`). The graph data is then physically moved to align with this new distribution for subsequent processing.
+*   `ProjectInfoBack` is used after computations (like partitioning) are done on a moved/redistributed graph, to transfer results (e.g., final partition vector) back to the original data distribution.
+*   `FindVtxPerm` might be used to prepare data for remapping or if a contiguous ordering by partition is needed.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions (`ctrl_t`, `graph_t`, `idx_t`, `ikv_t`), MPI wrappers, memory utilities.
+    *   `graph.c`: For `CreateGraph`.
+    *   `comm.c`: For `CommInterfaceData`, `CommUpdateNnbrs`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Extensively used for point-to-point and collective communication (`gkMPI_Scan`, `gkMPI_Allreduce`, `gkMPI_Alltoall`, `gkMPI_Isend`, `gkMPI_Irecv`, `gkMPI_Waitall`).
+*   **Other Interactions**:
+    *   `MoveGraph` results in a new `graph_t` structure (`mgraph`) with potentially different local `nvtxs` on each PE compared to the input `graph`.
+    *   The correctness of `ProjectInfoBack` relies on `graph->where` accurately reflecting how the data in `minfo` was distributed from the original `graph`.
+
+```

--- a/documentation/msetup.c.md
+++ b/documentation/msetup.c.md
@@ -1,0 +1,71 @@
+# libparmetis/msetup.c
+
+## Overview
+
+This file contains routines for setting up and initializing the `mesh_t` data structure in ParMETIS. The `mesh_t` structure is used to represent unstructured finite element meshes, which are inputs to mesh-based partitioning algorithms like `ParMETIS_V3_PartMeshKway`. The setup involves storing mesh element connectivity, element weights, and determining some global mesh properties like the range of node IDs.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`SetUpMesh(idx_t *etype, idx_t *ncon, idx_t *elmdist, idx_t *elements, idx_t *elmwgt, idx_t *wgtflag, MPI_Comm *comm)`**:
+    *   This function creates and initializes a `mesh_t` structure from user-provided mesh data.
+    *   **Parameters**:
+        *   `etype`: Pointer to the element type (e.g., triangle, tetrahedron).
+        *   `ncon`: Pointer to the number of weights per element (if weighted).
+        *   `elmdist`: Array defining the distribution of elements across processors.
+        *   `elements`: Array containing the node IDs for each element, concatenated.
+        *   `elmwgt`: Array of element weights (if `wgtflag` indicates).
+        *   `wgtflag`: Flag indicating if element weights are provided.
+        *   `comm`: MPI communicator.
+    *   **Functionality**:
+        1.  Gets MPI rank (`mype`) and size (`npes`).
+        2.  Creates a `mesh_t` structure (`CreateMesh`).
+        3.  Sets basic mesh properties: `elmdist`, `gnelms` (global number of elements), `nelms` (local number of elements), `elements` array, `elmwgt` array, `etype`, `ncon`.
+        4.  Determines `esize` (number of nodes per element) based on `etype`.
+        5.  If element weights are not provided (`wgtflag&1 == 0`), allocates and initializes `mesh->elmwgt` to 1 for each local element and constraint.
+        6.  Normalizes global node IDs:
+            *   Finds the global minimum node ID (`gminnode`) across all processors.
+            *   Subtracts `gminnode` from all node IDs in the local `elements` array. This makes node IDs start effectively from 0 globally for internal processing.
+            *   Stores `gminnode` in `mesh->gminnode` (to restore original numbering later if needed).
+        7.  Finds the global maximum of these normalized node IDs (`gmaxnode`) to determine `mesh->gnns` (global number of unique nodes).
+    *   Returns the initialized `mesh_t` structure.
+*   **`CreateMesh(void)`**:
+    *   Allocates memory for a `mesh_t` structure.
+    *   Calls `InitMesh` to initialize its fields to default null/invalid values.
+    *   Returns the allocated `mesh_t` pointer.
+*   **`InitMesh(mesh_t *mesh)`**:
+    *   Sets all fields of a `mesh_t` structure to zero or default invalid values (e.g., -1, NULL). This ensures a clean state before population.
+
+## Important Variables/Constants
+
+*   **`mesh_t` (struct)**: The central data structure for representing distributed meshes. Key members include:
+    *   `etype`: Type of mesh element (e.g., triangle, tetrahedron).
+    *   `esize`: Number of nodes per element of `etype`.
+    *   `ncon`: Number of weights associated with each element.
+    *   `elmdist`: Array defining the distribution of elements to PEs.
+    *   `nelms`, `gnelms`: Local and global number of elements.
+    *   `elements`: Concatenated list of node IDs for each local element.
+    *   `elmwgt`: Array of weights for local elements.
+    *   `nns`, `gnns`: Local (not explicitly stored/computed here) and global number of unique nodes.
+    *   `gminnode`: The minimum global node ID found in the input mesh, used for normalizing node IDs.
+*   **`esizes[5]` (local array in `SetUpMesh`)**: Maps `etype` to the number of nodes per element (e.g., `esizes[1]=3` for triangles if `etype=1` means triangle).
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions. `SetUpMesh` is called at the beginning of ParMETIS API functions that operate on meshes, such as `ParMETIS_V3_PartMeshKway` (via `mmetis.c`) or `ParMETIS_V3_Mesh2Dual` (via `mesh.c`, though `mesh.c` has its own setup logic which is more complex as it directly prepares for dual graph construction). `SetUpMesh` primarily prepares the `mesh_t` structure for basic access to mesh elements and their properties.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `mesh_t` definition, `idx_t` type, MPI wrappers (`gkMPI_Comm_size`, `gkMPI_Comm_rank`, `gkMPI_Allreduce`), memory management (`gk_malloc`, `ismalloc`), and math utilities (`imin`, `imax`).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for determining `gminnode` and `gmaxnode` via `gkMPI_Allreduce`.
+*   **Other Interactions**:
+    *   The `elements` array is modified in place by `SetUpMesh` to contain normalized node IDs (0-based with respect to the global minimum).
+    *   The `mesh_t` structure populated by `SetUpMesh` is then used by other functions, for example, as a precursor to building a dual graph of the mesh.
+
+```

--- a/documentation/mtest.c.md
+++ b/documentation/mtest.c.md
@@ -1,0 +1,64 @@
+# programs/mtest.c
+
+## Overview
+
+This file contains a test program (`mtest`) for ParMETIS, specifically designed to test the mesh partitioning capabilities, primarily `ParMETIS_V3_PartMeshKway`. It reads a mesh, optionally allows specifying the number of common nodes to define element adjacency for the dual graph, partitions the mesh (which involves internal dual graph creation and partitioning), and then likely (though not explicitly shown in the provided snippet) would perform some checks or report statistics.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`main(int argc, char *argv[])`**:
+    *   Entry point for the `mtest` program.
+    *   Initializes MPI.
+    *   Parses command-line arguments:
+        *   `argv[1]`: Mesh filename.
+        *   `argv[2]` (optional): Number of common nodes (`mgcnum`) to define adjacency in the dual graph. If not provided, it's derived from the mesh element type.
+    *   Calls `ParallelReadMesh` to read the distributed mesh data into a `mesh_t` structure.
+    *   Sets up parameters for `ParMETIS_V3_PartMeshKway`:
+        *   `nparts`: Set to `npes` (number of processors).
+        *   `tpwgts`: Target partition weights (equal for all parts).
+        *   `ubvec`: Uniform imbalance tolerance (`UNBALANCE_FRACTION`).
+        *   `options`: Basic ParMETIS options (enable options, set debug level, seed).
+    *   The `eptr` array (element pointers for node lists) is artificially modified for the last element (`eptr[nelms]--`). This seems like a specific test case or a way to introduce a slight irregularity, but its exact purpose is unclear without further context. **Correction**: `MAKECSR(i, nelms, eptr)` converts `eptr` from element sizes to CSR format. The `eptr[nelms]--` then seems to be an intentional modification *after* CSR conversion, potentially to test robustness or a specific scenario. *Further Correction*: `ismalloc(nelms+1, esizes[mesh.etype], "main; eptr")` initializes `eptr` with `esizes[mesh.etype]` for all entries. Then `MAKECSR` creates the CSR structure. The `eptr[nelms]--` is indeed a peculiar modification to the last element's degree if `esizes` was uniform.
+    *   Calls `ParMETIS_V3_PartMeshKway` to partition the mesh.
+    *   Frees allocated memory and finalizes MPI.
+
+## Important Variables/Constants
+
+*   **`mesh` (mesh_t)**: Structure holding the distributed mesh data.
+*   **`part` (idx_t *)**: Array to store the computed partition for each local element.
+*   **`mgcnum` (idx_t)**: Number of common nodes to define an edge in the dual graph. Derived from `mesh.etype` or command line.
+*   **`esizes` (array)**: Maps element type to number of nodes per element.
+*   **`mgcnums` (array)**: Maps element type to default `ncommon` value.
+*   **`UNBALANCE_FRACTION`**: Default imbalance tolerance.
+*   `options`: Array to pass options to ParMETIS.
+
+## Usage Examples
+
+```bash
+# Command-line execution:
+mpirun -np <num_procs> mtest <mesh_file_name> [num_common_nodes]
+
+# Example:
+mpirun -np 4 mtest my_mesh.msh 3
+# This would partition my_mesh.msh into 4 partitions, using 3 common nodes
+# to determine element adjacency for the internal dual graph.
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` and other common headers.
+    *   `io.c` (programs/io.c): For `ParallelReadMesh`.
+    *   `parmetis.h` (ParMETIS library API): `ParMETIS_V3_PartMeshKway` is the main API call being tested.
+    *   `parmetislib.h` (indirectly): For `mesh_t`, `idx_t`, `real_t`, MPI wrappers, memory utilities (`imalloc`, `ismalloc`, `rmalloc`, `gk_free`, `gk_malloc_init`, `gk_malloc_cleanup`, `MAKECSR`).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For parallel execution.
+    *   Standard C library: For `printf`, `exit`, `atoi`.
+*   **Other Interactions**:
+    *   This program serves as a driver to test the mesh partitioning functionality of ParMETIS.
+    *   It reads a mesh, partitions it, and would typically be used in conjunction with result analysis (e.g., checking edge cuts, balance, or visualizing the partition) which is not shown in the snippet.
+    *   The modification of `eptr[nelms]` is unusual and might be a specific test for robustness or a particular graph structure.
+
+```

--- a/documentation/node_refine.c.md
+++ b/documentation/node_refine.c.md
@@ -1,0 +1,82 @@
+# libparmetis/node_refine.c
+
+## Overview
+
+This file contains routines specifically designed for k-way node-based refinement, primarily used in the context of parallel nested dissection ordering (`ometis.c`). Unlike edge-based refinement which focuses on edge cuts, node-based refinement typically aims to minimize the size of the vertex separator. These routines manage data structures for node refinement (`NRInfoType`), compute parameters like external degrees to different partitions, and implement greedy refinement strategies.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`AllocateNodePartitionParams(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Allocates memory for data structures required for node-based refinement.
+    *   `graph->nrinfo` (array of `NRInfoType`): Stores refinement information for each node, particularly its external degrees to different sides of a bisection/multisection.
+    *   `graph->lpwgts`, `graph->gpwgts`: Local and global partition weights (often, 0 for part A, 1 for part B, and 2+ for separators).
+    *   `graph->sepind`: Array to store indices of separator vertices.
+    *   Reallocates `graph->vwgt` to include space for ghost vertex weights.
+*   **`ComputeNodePartitionParams(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Computes initial parameters for node refinement. Assumes `AllocateNodePartitionParams` has been called.
+    *   Communicates `where` (partition assignments) and `vwgt` (vertex weights) for interface vertices.
+    *   For each local vertex:
+        *   Updates `lpwgts` based on its `where` and `vwgt`.
+        *   If it's a separator vertex (`where[i] >= nparts`):
+            *   Adds it to `sepind`.
+            *   Calculates `rinfo[i].edegrees[0]` and `rinfo[i].edegrees[1]`, which are the sum of `vwgt` of its neighbors in partition 0 and partition 1 (or `part_A_of_sep_i` and `part_B_of_sep_i`).
+    *   Updates `graph->nsep` (number of local separator vertices).
+    *   Computes global partition weights `gpwgts` and `graph->mincut` (total weight of separator vertices).
+*   **`UpdateNodePartitionParams(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Similar to `ComputeNodePartitionParams`, but called after some vertices might have changed their `where` status (e.g., moved into or out of a separator). Recomputes `lpwgts`, `gpwgts`, `sepind`, `nsep`, and `edegrees` for separator nodes.
+*   **`KWayNodeRefine_Greedy(ctrl_t *ctrl, graph_t *graph, idx_t npasses, real_t ubfrac)`**:
+    *   Performs k-way node-based greedy refinement.
+    *   Aims to move separator nodes into one of the partitions if doing so is beneficial (reduces overall "cost" or improves balance) and maintains balance constraints (`badmaxpwgt`).
+    *   Iterates for `npasses` or until no improvement. Each pass has two `side` iterations (0 and 1).
+    *   Uses a priority queue (`rpq_t`) to select separator nodes to move. The key for a node `i` in the queue is `vwgt[i] - rinfo[i].edegrees[cc]`, where `cc` is the side opposite to the target move side `c`. This prioritizes nodes with small external degree to the non-target side.
+    *   If a move is made:
+        *   Updates `where`, `lpwgts`, `gpwgts`.
+        *   Identifies neighboring vertices whose `edegrees` might change and updates them in the priority queue or marks them for broader update.
+        *   Communicates changes to `where` for interface vertices (`CommChangedInterfaceData`) and lists of vertices needing `edegree` updates.
+    *   The refinement alternates between trying to move nodes to partition `c` and then to partition `cc`.
+*   **`KWayNodeRefine2Phase(ctrl_t *ctrl, graph_t *graph, idx_t npasses, real_t ubfrac)`**:
+    *   A two-phase refinement strategy.
+    *   Repeatedly calls `KWayNodeRefine_Greedy` and then `KWayNodeRefineInterior`.
+    *   After each call, it updates partition parameters (`UpdateNodePartitionParams`).
+    *   Stops if no improvement in `graph->mincut` (separator size).
+*   **`KWayNodeRefineInterior(ctrl_t *ctrl, graph_t *graph, idx_t npasses, real_t ubfrac)`**:
+    *   Refines interior nodes (non-interface nodes) of each local "subgraph" (formed by a pair of partitions and their separator, e.g., `gid`, `gid+1`, `nparts+gid`).
+    *   It extracts these local subgraphs, converts them to a format suitable for serial METIS node refinement (`METIS_NodeRefine`), calls it, and then maps the results back to the global `graph->where` array.
+*   **`PrintNodeBalanceInfo(ctrl_t *ctrl, idx_t nparts, idx_t *gpwgts, idx_t *badmaxpwgt, char *title)`**:
+    *   A utility function to print balance information related to node-based partitioning (weights of parts 0, 1, and their separator, against `badmaxpwgt`).
+
+## Important Variables/Constants
+
+*   **`graph->nrinfo` (array of `NRInfoType`)**: Stores `edegrees[2]` for separator nodes, representing sum of neighbor weights in partition 0 and 1 relative to the separator.
+*   **`graph->lpwgts`, `graph->gpwgts`**: Partition weights. For node refinement, indices `0` to `nparts-1` usually refer to the actual partitions, and `nparts` to `2*nparts-1` might refer to separators, with `2*nparts-1` often being a total separator weight.
+*   **`graph->sepind`**: Array storing indices of local separator vertices.
+*   **`graph->nsep`**: Number of local separator vertices.
+*   **`badmaxpwgt`**: Maximum allowed weight for partitions, derived from `ubfrac` and current partition weights.
+*   `queue (rpq_t *)`: Priority queue used in `KWayNodeRefine_Greedy`.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions, primarily called by the parallel nested dissection ordering algorithm (`ometis.c`).
+*   `AllocateNodePartitionParams` and `ComputeNodePartitionParams` (or `UpdateNodePartitionParams`) are called to initialize or refresh data needed for refinement.
+*   `KWayNodeRefine_Greedy` or `KWayNodeRefine2Phase` are then called to perform the actual refinement of the vertex separators.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions (`ctrl_t`, `graph_t`, `NRInfoType`, `idx_t`, `rpq_t`), MPI wrappers, memory utilities, GKlib priority queue functions (`rpqCreate`, `rpqInsert`, etc.).
+    *   `comm.c`: `CommInterfaceData`, `CommChangedInterfaceData`, `GlobalSESum`.
+    *   `ometis.c`: These functions are central to the refinement steps within the multilevel ordering process.
+    *   `metis.h` (external METIS library): `METIS_NodeRefine` is called by `KWayNodeRefineInterior`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For communication.
+    *   `METIS`: Serial METIS library for interior node refinement.
+*   **Other Interactions**:
+    *   These routines modify `graph->where` by moving nodes into or out of separators, and update `graph->mincut` (total separator size).
+    *   The refinement process is sensitive to the `ubfrac` (imbalance tolerance) parameter.
+
+```

--- a/documentation/ometis.c.md
+++ b/documentation/ometis.c.md
@@ -1,0 +1,107 @@
+# libparmetis/ometis.c
+
+## Overview
+
+This file implements the parallel nested dissection ordering algorithm in ParMETIS. The primary API function is `ParMETIS_V3_NodeND` (and its tunable version `ParMETIS_V32_NodeND`). Nested dissection is a graph algorithm used to find a fill-reducing ordering for sparse matrix factorization. It recursively bisects (or multisects) the graph, ordering separator vertices last. This file orchestrates the multilevel version of this process.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_V3_NodeND(idx_t *vtxdist, ..., MPI_Comm *comm)`**:
+    *   The main V3 API function for parallel node nested dissection.
+    *   Performs input checks (`CheckInputsNodeND`).
+    *   Calls `ParMETIS_V32_NodeND` with default or derived parameters for matching type, refinement type, etc.
+*   **`ParMETIS_V32_NodeND(idx_t *vtxdist, ..., idx_t *order, idx_t *sizes, MPI_Comm *comm)`**:
+    *   The tunable version of the parallel node nested dissection algorithm.
+    *   **Steps**:
+        1.  **Initial Partitioning for Distribution**:
+            *   Sets up a `ctrl_t` structure (initially for `PARMETIS_OP_KMETIS`).
+            *   Calls `Global_Partition` to get an initial `k`-way partition (where `k` is often `5*npes`). This is primarily to distribute the graph reasonably for subsequent ordering steps, not the final ordering itself.
+            *   The resulting `graph->where` is collapsed to `npes` partitions.
+        2.  **Move Graph**: Calls `MoveGraph` to redistribute the graph according to this `npes`-way partition. The moved graph is `mgraph`.
+        3.  **Multilevel Ordering on Moved Graph**:
+            *   Sets `ctrl->optype = PARMETIS_OP_OMETIS`.
+            *   Sets parameters like `mtype` (matching type), `rtype` (refinement type for separators), `p_nseps`/`s_nseps` (number of separators to try), `ubfrac`.
+            *   Calls `MultilevelOrder` on `mgraph` to compute the actual nested dissection ordering. The ordering is stored in `morder`, and separator sizes in `sizes`.
+        4.  **Project Ordering Back**: Projects `morder` from `mgraph`'s distribution back to the original graph's distribution using `ProjectInfoBack`, storing it in `order`.
+        5.  Frees structures and performs cleanup.
+*   **`MultilevelOrder(ctrl_t *ctrl, graph_t *graph, idx_t *order, idx_t *sizes)`**:
+    *   The core multilevel nested dissection driver.
+    *   `npes` is effectively the number of "parts" in the recursive dissection (must be power of 2).
+    *   Initializes `perm` (tracks vertex identity through compaction) and `lastnode` (tracks available numbering range for separators).
+    *   Iteratively calls `Order_Partition_Multiple` for `nparts = 2, 4, ..., npes`. In each iteration:
+        *   `Order_Partition_Multiple` finds separators that divide current partitions.
+        *   `LabelSeparators` assigns order numbers to the newly found separator vertices (from high to low).
+        *   `CompactGraph` removes the separator vertices, creating a new graph of disconnected components for the next level of dissection.
+    *   After all separator levels are found:
+        *   The remaining disconnected components (now distributed one per PE that is part of the `npes` active set) are ordered locally using `LocalNDOrder`.
+        *   The local orderings are projected back.
+*   **`Order_Partition_Multiple(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Computes node separators for the current `graph` to achieve `ctrl->nparts` way separation.
+    *   It performs `ctrl->p_nseps` iterations of calling `Order_Partition`.
+    *   In each iteration, it tries to find a better set of separators than the previous one. The `bestwhere` and `bestseps` arrays store the best separator found so far for each bisection.
+    *   After iterations, it finalizes `graph->where` with the overall best separators and computes node partition params.
+*   **`Order_Partition(ctrl_t *ctrl, graph_t *graph, idx_t *nlevels, idx_t clevel)`**:
+    *   A recursive multilevel function to find separators for the current `graph`.
+    *   **Base Case**: If graph is small enough (`graph->gnvtxs < 1.66*ctrl->CoarsenTo`) or coarsening hasn't reduced size much:
+        *   Calls `InitMultisection` to compute separators on this coarsest graph.
+        *   If it's the original graph (no coarsening happened), calls node-based refinement (`KWayNodeRefine_Greedy` or `KWayNodeRefine2Phase`).
+    *   **Recursive Step**:
+        *   Coarsens graph using `Match_Local` or `Match_Global`.
+        *   Recursively calls `Order_Partition` on `graph->coarser`.
+        *   Projects partition from coarser graph (`ProjectPartition`).
+        *   Refines the projected separators using `KWayNodeRefine_Greedy` or `KWayNodeRefine2Phase`.
+*   **`LabelSeparators(ctrl_t *ctrl, graph_t *graph, idx_t *lastnode, idx_t *perm, idx_t *order, idx_t *sizes)`**:
+    *   Assigns global order numbers to vertices identified as separators in `graph->where`.
+    *   Separator vertices are numbered from `lastnode[sid] - 1` downwards.
+    *   `lastnode` keeps track of the next available global order number for each separator tree branch.
+    *   `sizes` array is populated with the actual sizes of these separators.
+*   **`CompactGraph(ctrl_t *ctrl, graph_t *graph, idx_t *perm)`**:
+    *   Removes separator vertices (those with `where[i] >= nparts`) from `graph`.
+    *   The remaining disconnected components (vertices with `where[i] < nparts`) form the graph for the next level of nested dissection.
+    *   Updates `graph->vtxdist`, `graph->nvtxs`, `graph->nedges`, `graph->gnvtxs`, and `graph->where` (re-labeling components `0` to `nparts-1`).
+    *   `perm` array is updated to track original vertex indices through compaction.
+*   **`LocalNDOrder(ctrl_t *ctrl, graph_t *graph, idx_t *order, idx_t firstnode)`**:
+    *   Called on each PE once the graph is fully dissected into `npes` components, each local to a PE.
+    *   Performs serial nested dissection ordering (`METIS_NodeND`) on the local graph component.
+    *   The local ordering is assigned global order numbers starting from `firstnode`.
+
+## Important Variables/Constants
+
+*   **`order`**: Output array storing the fill-reducing permutation.
+*   **`sizes`**: Output array, `sizes[0...npes-1]` stores sizes of dissected subdomains, `sizes[npes...2*npes-2]` stores separator sizes.
+*   **`graph->where`**: Used dynamically to store current partition (0/1 for bisection) or separator assignments (>= `nparts`).
+*   **`perm` (in `MultilevelOrder`, `CompactGraph`)**: Tracks original vertex indices across graph compactions.
+*   **`lastnode` (in `MultilevelOrder`, `LabelSeparators`)**: Tracks the highest available order number for different branches of the separator tree.
+*   `ctrl->mtype`, `ctrl->rtype`, `ctrl->p_nseps`, `ctrl->s_nseps`, `ctrl->ubfrac`: Control parameters for matching, refinement, and balance.
+
+## Usage Examples
+This file implements API functions `ParMETIS_V3_NodeND` and `ParMETIS_V32_NodeND`.
+```c
+// Conceptual call to ParMETIS_V3_NodeND
+// (assuming vtxdist, xadj, adjncy, order, sizes, comm are set up)
+// idx_t numflag = 0;
+// idx_t options[METIS_NOPTIONS]; options[0] = 0; // Default options
+//
+// ParMETIS_V3_NodeND(vtxdist, xadj, adjncy, &numflag, options, order, sizes, &comm);
+//
+// // 'order' now contains the fill-reducing permutation.
+// // 'sizes' contains the sizes of the separators.
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions.
+    *   `ctrl.c`, `graph.c`, `comm.c`, `wspace.c`, `move.c`, `match.c`, `kwayrefine.c` (for `ProjectPartition`), `node_refine.c`, `initmsection.c`, `util.c`.
+    *   `kmetis.c`: `Global_Partition` is used for initial graph distribution.
+    *   `metis.h` (external METIS library): `METIS_NodeNDP` (in `pspases.c` context, but `METIS_NodeND` here) for local ordering.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`.
+    *   `METIS` (for local ordering).
+*   **Other Interactions**:
+    *   This is a complex orchestration of coarsening, partitioning (bisection/multisection), separator refinement, and graph compaction to achieve a nested dissection ordering.
+    *   The `sizes` array provides information about the structure of the separator tree.
+
+```

--- a/documentation/otest.c.md
+++ b/documentation/otest.c.md
@@ -1,0 +1,84 @@
+# programs/otest.c
+
+## Overview
+
+This file serves as a test driver program for various ParMETIS V3 API functions, including k-way partitioning (`ParMETIS_V3_PartKway`), geometric k-way partitioning (`ParMETIS_V3_PartGeomKway`), geometric partitioning based on coordinates only (`ParMETIS_V3_PartGeom`), k-way partition refinement (`ParMETIS_V3_RefineKway`), adaptive repartitioning (`ParMETIS_V3_AdaptiveRepart`), and node nested dissection ordering (`ParMETIS_V3_NodeND`). It reads a graph and optionally its coordinates, then calls these API functions with a range of parameters (number of constraints, number of parts, different internal options) to test their functionality and reports the resulting edge cuts.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`main(idx_t argc, char *argv[])`**:
+    *   Entry point for the `otest` program.
+    *   Initializes MPI.
+    *   Requires one command-line argument: the graph filename.
+    *   Calls `TestParMetis_GPart` (which seems to be a typo and should be `TestParMetis`, as defined in this file) to run the tests.
+    *   Finalizes MPI.
+*   **`TestParMetis(char *filename, MPI_Comm comm)`**:
+    *   The main testing logic.
+    *   Reads the graph using `ParallelReadGraph` and coordinates using `ReadTestCoordinates`.
+    *   Iterates through different numbers of partitions (`nparts`) and constraints (`ncon`).
+    *   For multi-constraint tests, it calls `Mc_AdaptGraph` to create varying vertex weights based on a temporary partition. For single constraint, it sets unit vertex weights.
+    *   **Tests `ParMETIS_V3_PartKway`**: Calls with `ncon` and `nparts`, and with `options[2]` (related to internal strategy) set to 1 and 2.
+    *   **Tests `ParMETIS_V3_PartGeomKway`**: Calls with similar parameters as `PartKway`, including coordinates.
+    *   **Tests `ParMETIS_V3_PartGeom`**: (Currently commented out in the provided code).
+    *   **Tests `ParMETIS_V3_RefineKway`**:
+        *   First, calls it on the initial graph state.
+        *   Then, computes a partition using `ParMETIS_V3_PartKway` (quietly, `options[0]=0`), moves the graph using `TestMoveGraph` to create `mgraph`, and then calls `RefineKway` on `mgraph` for various `ncon` and `options[2]`.
+    *   **Tests `ParMETIS_V3_AdaptiveRepart`**:
+        *   Uses the `mgraph` (moved graph from previous step).
+        *   Modifies vertex weights of `mgraph` using `AdaptGraph` (for `ncon=1`) or `Mc_AdaptGraph` (for `ncon>1`).
+        *   Calls `AdaptiveRepart` with varying `ipc2redist` values and `options[2]`.
+    *   **Tests `ParMETIS_V3_NodeND`**: Calls with `options[PMV3_OPTION_IPART]` (initial partitioning type for ND) set to 1 and 2.
+    *   Prints reported edge cuts for each test.
+*   **`ComputeRealCut(idx_t *vtxdist, idx_t *part, char *filename, MPI_Comm comm)`**:
+    *   Gathers the distributed partition vector `part` onto PE 0.
+    *   PE 0 reads the original graph (serially using `ReadMetisGraph`) and computes the actual edge cut based on `gpart`.
+*   **`ComputeRealCut2(idx_t *vtxdist, idx_t *mvtxdist, idx_t *part, idx_t *mpart, char *filename, MPI_Comm comm)`**:
+    *   Similar to `ComputeRealCut`, but for a scenario involving an original partition `part` and a partition `mpart` on a moved graph.
+    *   It reconstructs the permutation (`perm`) to map original vertex indices to moved graph vertex indices based on `gpart` (gathered `part`).
+    *   Then computes the cut on the original graph structure using `gmpart[perm[vertex]]`.
+*   **`TestMoveGraph(graph_t *ograph, graph_t *omgraph, idx_t *part, MPI_Comm comm)`**:
+    *   A wrapper to test the `MoveGraph` functionality from `libparmetis`.
+    *   It sets up a temporary `ctrl_t` and `wspace_t`, calls `Mc_SetUpGraph` (seems to be an older or internal version of `SetupGraph`), then `SetUp` (unknown, possibly older comm setup), then `MoveGraph`.
+    *   Copies key fields from the returned `mgraph` to `omgraph`.
+*   **`SetUpGraph(ctrl_t *ctrl, idx_t *vtxdist, ..., idx_t wgtflag)`**:
+    *   A wrapper around `Mc_SetUpGraph` (older/internal graph setup) for use within `TestMoveGraph`.
+
+## Important Variables/Constants
+
+*   `graph` (graph_t): Holds the primary distributed graph.
+*   `mgraph` (graph_t): Holds the "moved" graph after redistribution.
+*   `part`, `mpart`, `savepart`, `order`, `sizes`: Arrays for storing partitioning and ordering results.
+*   `xyz`: Array for vertex coordinates.
+*   `options`: Array to control ParMETIS behavior.
+*   `MAXNCON`: Used for allocating `tpwgts` and `ubvec`.
+
+## Usage Examples
+
+```bash
+# Command-line execution:
+mpirun -np <num_procs> otest <graph_file_name>
+
+# Example:
+mpirun -np 4 otest mygraph.graph
+```
+This program reads `mygraph.graph` and its coordinate file (`mygraph.graph.xyz`), then runs a battery of tests on it using 4 processors.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` and `programs/proto.h`.
+    *   `programs/io.c`: For `ParallelReadGraph`, `ReadTestCoordinates`, `ReadMetisGraph`.
+    *   `programs/adaptgraph.c`: For `AdaptGraph`, `Mc_AdaptGraph`.
+    *   `libparmetis/parmetis.h` (API): Calls `ParMETIS_V3_PartKway`, `ParMETIS_V3_PartGeomKway`, `ParMETIS_V3_RefineKway`, `ParMETIS_V3_AdaptiveRepart`, `ParMETIS_V3_NodeND`.
+    *   `libparmetis` (internal functions, likely through `parmetisbin.h`): `SetUpCtrl`, `Mc_SetUpGraph` (older graph setup), `MoveGraph`, `FreeInitialGraphAndRemap`, `FreeGraph`, `FreeWSpace`, `MALLOC_CHECK`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`.
+    *   Standard C library.
+*   **Other Interactions**:
+    *   `otest.c` is a comprehensive test driver that exercises multiple ParMETIS API functions with varied parameters, making it useful for regression testing and validation.
+    *   The `TestMoveGraph` and the local `SetUpGraph` wrapper suggest it might be testing against an older or specific internal way of setting up and moving graphs, possibly for backward compatibility checks or focused testing of those components.
+    *   The file `ptest.c` is mentioned in the original `$Id$` comment, and `otest.c` seems to be a modified or evolved version of it, likely focusing more on ordering (`_NodeND`) tests.
+
+```

--- a/documentation/parmetis.c.md
+++ b/documentation/parmetis.c.md
@@ -1,0 +1,86 @@
+# programs/parmetis.c
+
+## Overview
+
+This file contains the `main` function for the `parmetis` command-line executable. This program serves as a general-purpose driver for several ParMETIS V3 API functions, allowing users to partition graphs or compute vertex orderings from the command line by specifying the operation type and various parameters.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`main(int argc, char *argv[])`**:
+    *   Entry point for the `parmetis` executable.
+    *   Initializes MPI.
+    *   **Command-line Argument Parsing**:
+        *   Expects 7 arguments:
+            1.  `graph-file`: The name of the file containing the graph.
+            2.  `op-type`: Integer specifying the ParMETIS operation to perform (see below).
+            3.  `nparts`: Number of partitions desired.
+            4.  `adapt-factor`: Adaptation factor (used by `AdaptGraph` for op-type 3).
+            5.  `ipc2redist`: IPC to redistribution factor (for op-type 3).
+            6.  `dbglvl`: Debug level for ParMETIS options.
+            7.  `seed`: Random seed for ParMETIS options.
+    *   Reads the distributed graph using `ParallelReadGraph`.
+    *   Initializes `tpwgts` (target partition weights) for equal distribution and `ubvec` (imbalance tolerance) to 1.05.
+    *   Optionally reads coordinates if `optype >= 20` (geometric operations).
+    *   Allocates `part` (for partition vector) and `sizes` (for ordering results).
+    *   **Operation Dispatch (based on `optype`)**:
+        *   `optype == 1`: Calls `ParMETIS_V3_PartKway` for k-way partitioning. Writes partition vector.
+        *   `optype == 2`: Calls `ParMETIS_V3_RefineKway` to refine an existing partition (implicitly, `part` would need to be initialized, though it's initialized to `mype % nparts` here which might not be a meaningful existing partition unless `nparts` is related to `npes`). Writes partition vector.
+        *   `optype == 3`: Calls `ParMETIS_V3_AdaptiveRepart`.
+            *   If `npes > 1`, adapts graph using `AdaptGraph`.
+            *   If `npes == 1`, first partitions with `PartKway` to get an initial `part` vector, then adapts vertex weights based on this partition and `adptf`.
+        *   `optype == 4`: Calls `ParMETIS_V3_NodeND` for parallel nested dissection ordering. (Output writing commented out).
+        *   `optype == 5`: Calls `ParMETIS_SerialNodeND` (assembles graph on PE0, then serial ND). Prints `sizes`. (Output writing commented out).
+        *   `optype == 11`: (Commented out - `TestAdaptiveMETIS`).
+        *   `optype == 20`: Calls `ParMETIS_V3_PartGeomKway` for geometric k-way partitioning.
+        *   `optype == 21`: Calls `ParMETIS_V3_PartGeom` for coordinate-based partitioning.
+    *   Frees allocated memory and finalizes MPI.
+*   **`ChangeToFortranNumbering(idx_t *vtxdist, idx_t *xadj, idx_t *adjncy, idx_t mype, idx_t npes)`**:
+    *   (Duplicate of the function in `libparmetis/renumber.c`). Converts graph arrays from 0-based to 1-based indexing.
+    *   *(This is commented out in the `main` function, suggesting 0-based is default for this driver)*.
+
+## Important Variables/Constants
+
+*   `optype`: Command-line argument determining which ParMETIS API function to call.
+*   `nparts`: Desired number of partitions.
+*   `adptf`: Adaptation factor for `AdaptGraph`.
+*   `ipc2redist`: IPC to redistribution ratio for adaptive repartitioning.
+*   `options`: Array to set `dbglvl` and `seed` for ParMETIS calls.
+*   `graph` (graph_t): Stores the distributed graph.
+*   `part` (idx_t *): Stores the resulting partition vector.
+*   `sizes` (idx_t *): Stores separator sizes for ordering.
+*   `xyz` (real_t *): Stores vertex coordinates for geometric operations.
+*   `MAXNCON`: Used for `ubvec` size.
+
+## Usage Examples
+
+```bash
+# Command-line execution:
+mpirun -np <num_procs> parmetis <graphfile> <optype> <nparts> <adaptfactor> <ipc2redist> <dbglvl> <seed>
+
+# Example: Partition 'mygraph.graph' into 4 parts using k-way partitioning
+mpirun -np 4 parmetis mygraph.graph 1 4 10 1.0 0 0
+
+# Example: Order 'mygraph.graph' using parallel nested dissection
+mpirun -np 4 parmetis mygraph.graph 4 4 10 1.0 0 0
+# (nparts, adaptfactor, ipc2redist might be ignored for optype 4)
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` and `programs/proto.h`.
+    *   `programs/io.c`: For `ParallelReadGraph`, `ReadTestCoordinates`, `WritePVector`, `WriteOVector`.
+    *   `programs/adaptgraph.c`: For `AdaptGraph`.
+    *   `libparmetis/parmetis.h` (API): Calls various `ParMETIS_V3_*` functions.
+    *   `libparmetis/pspases.c`: `ParMETIS_SerialNodeND` is called for `optype == 5`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`.
+    *   Standard C library (stdio, stdlib, string).
+*   **Other Interactions**:
+    *   This program acts as a command-line frontend to the ParMETIS library, allowing users to invoke different parallel graph algorithms.
+    *   The specific combination of parameters and `optype` determines the exact workflow and ParMETIS functions called.
+    *   Output (partition files, ordering files) is written for some operations.
+
+```

--- a/documentation/parmetisbin.h.md
+++ b/documentation/parmetisbin.h.md
@@ -1,0 +1,76 @@
+# programs/parmetisbin.h
+
+## Overview
+
+This header file serves as a common include file for the executable programs (test drivers, command-line tools) in the ParMETIS `programs` directory, such as `parmetis`, `mtest`, `ptest`, `otest`, and `dglpart`. It bundles essential headers from both the ParMETIS library (`libparmetis`) and standard libraries, providing a convenient way to include all necessary definitions and declarations for these programs.
+
+## Key Components
+
+This file's main role is to include other header files.
+
+### Included Library Headers:
+
+*   **`GKlib.h`**: The main header for George Karypis's GKlib. This provides low-level utilities for memory management, sorting, data structures, etc., which are used by both ParMETIS library internals and potentially the test programs themselves.
+*   **`parmetis.h`**: The public API header for the ParMETIS library. This defines the functions that users (and these test programs) call (e.g., `ParMETIS_V3_PartKway`), as well as user-visible constants and type definitions (like `idx_t`, `real_t`).
+
+### Included Internal ParMETIS Headers (from `libparmetis`):
+
+These headers provide access to internal data structures, constants, macros, and function prototypes of the ParMETIS library, which might be needed by more sophisticated test programs or drivers that interact closely with internal components (though direct use of internal functions is generally for testing/debugging).
+
+*   **`gklib_defs.h`**: ParMETIS-specific header for GKlib data structures and renamed function prototypes.
+*   **`rename.h`**: Macros to rename internal ParMETIS functions (e.g., `Match_Global` to `libparmetis__Match_Global`) to avoid symbol clashes. This implies the test programs might also be compiled with these renames active if they call internal functions directly.
+*   **`defs.h`**: Global constant definitions used throughout ParMETIS (default parameters, algorithm thresholds, debug flags).
+*   **`struct.h`**: Core internal ParMETIS data structures (`ctrl_t`, `graph_t`, `mesh_t`, etc.).
+*   **`macros.h`**: Utility macros (timers, assertions, workspace management).
+*   **`../libparmetis/proto.h`**: Function prototypes for internal C functions within the `libparmetis` directory. (Note the relative path `../libparmetis/` which is correct as this header is in `programs/`).
+
+### Included Program-Specific Header:
+
+*   **`proto.h`**: This refers to `programs/proto.h`, which would contain function prototypes for functions defined within the `programs` directory itself (e.g., I/O routines in `programs/io.c`, test utility functions).
+
+### Constants
+*   **`MAXNCON`**: Defines the maximum number of constraints to be 32. This is likely used for statically allocating arrays related to constraints in the test programs.
+
+### Preprocessor Defines (Example):
+```c
+/*
+#define DEBUG			1
+#define DMALLOC			1
+*/
+```
+These lines (commented out by default) suggest options for enabling general debugging flags or a specific dynamic memory allocation library (DMALLOC) during development of the test programs or the library.
+
+## Important Variables/Constants
+
+*   **`MAXNCON`**: Maximum number of constraints supported by arrays sized with this constant in the test programs.
+*   Other constants and types are inherited from the included headers (e.g., `idx_t`, `real_t` from `parmetis.h`; various algorithm parameters from `libparmetis/defs.h`).
+
+## Usage Examples
+
+```c
+// In any ParMETIS program .c file (e.g., parmetis.c, otest.c):
+#include <parmetisbin.h> // Note: typically just "parmetisbin.h" if include paths are set up
+
+// After this include, the .c file has access to:
+// - ParMETIS API functions, types, and constants.
+// - MPI functions (via parmetis.h or GKlib.h).
+// - GKlib utility functions.
+// - Internal ParMETIS structures, constants, and macros (use with caution, primarily for testing).
+// - Prototypes for other functions within the programs directory (via programs/proto.h).
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies (ParMETIS library)**:
+    *   Relies heavily on the headers from the `libparmetis` directory.
+    *   The test programs built using this header link against the compiled ParMETIS library.
+*   **Internal Dependencies (programs directory)**:
+    *   Includes `proto.h` from its own directory for inter-program-module function calls.
+*   **External Libraries**:
+    *   `MPI`: Included via `parmetis.h`.
+    *   `GKlib`: Included via `GKlib.h`. The ParMETIS build system must provide these.
+*   **Other Interactions**:
+    *   This header file is a key part of building the executable programs provided with ParMETIS.
+    *   It ensures that these programs have a consistent view of all necessary definitions from the ParMETIS library and its dependencies.
+
+```

--- a/documentation/parmetislib.h.md
+++ b/documentation/parmetislib.h.md
@@ -1,0 +1,67 @@
+# libparmetis/parmetislib.h
+
+## Overview
+
+This is the primary internal header file for the ParMETIS library. It acts as a central include point that brings together all necessary definitions, structures, macros, and function prototypes required by the various modules within ParMETIS. By including `parmetislib.h`, a ParMETIS source file gains access to MPI, GKlib (via its ParMETIS-specific integration headers), the public ParMETIS API (`parmetis.h`), internal constant definitions, data structure definitions, utility macros, and prototypes for almost all internal ParMETIS functions.
+
+## Key Components
+
+This file's main role is to include other header files in the correct order.
+
+### Included Headers:
+
+*   **`mpi.h`**: Standard MPI header for parallel communication.
+*   **`GKlib.h`**: The main header for George Karypis's GKlib. In ParMETIS, this is typically a modified or embedded version. It provides low-level utilities for memory management, sorting, data structures, etc.
+*   **`parmetis.h`**: The public API header for ParMETIS. This defines the functions that users of the ParMETIS library call (e.g., `ParMETIS_V3_PartKway`), as well as user-visible constants and type definitions (like `idx_t`, `real_t`).
+*   **`gklib_defs.h`**: ParMETIS-specific header that defines certain GKlib data structures (like `ikv_t`, `rpq_t`) using GKlib macros and declares prototypes for the ParMETIS-embedded GKlib functions (which are renamed, e.g., `libparmetis__iset`).
+*   **`rename.h`**: Contains macros to rename internal ParMETIS functions, often to avoid conflicts with other libraries or to provide different versions (e.g., Fortran wrappers are handled differently, but this `rename.h` might be for internal C function aliasing or versioning if used beyond just GKlib renames). *Self-correction: The primary `rename.h` seen so far (`gklib_rename.h`) is for GKlib symbols. This `rename.h` might be more general or related to other internal aliasing if it's distinct.* Based on `proto.h` also including `rename.h`, it's likely for broader internal use or a legacy aspect.
+*   **`defs.h`**: Contains global constant definitions used throughout ParMETIS (e.g., default parameters, algorithm thresholds, debug flags).
+*   **`struct.h`**: Defines the core internal data structures used by ParMETIS, most notably `ctrl_t` (control structure) and `graph_t` (graph structure), `NRInfoType`, `cnbr_t`, `matrix_t`, `mesh_t`.
+*   **`macros.h`**: Defines utility macros for timers, assertions, workspace management, etc.
+*   **`proto.h`**: Contains function prototypes for most of the internal C functions within the `libparmetis` directory. This ensures that functions can call each other across different `.c` files.
+
+### Preprocessor Defines (Example):
+```c
+/*
+#define DEBUG			1
+#define DMALLOC			1
+*/
+```
+These lines (commented out by default) suggest options for enabling general debugging flags or a specific dynamic memory allocation library (DMALLOC) during development.
+
+## Important Variables/Constants
+
+This file itself doesn't define variables or constants directly but includes headers that do:
+*   `parmetis.h`: User-level constants (e.g., `PARMETIS_OK`, option keys).
+*   `defs.h`: Internal algorithm constants and debug flags.
+*   `struct.h`: Definitions of `idx_t`, `real_t` (often through `metis.h` included by `parmetis.h`).
+
+## Usage Examples
+
+```c
+// In any ParMETIS internal .c file (e.g., kmetis.c, match.c):
+#include <parmetislib.h>
+
+// After this include, the .c file has access to:
+// - MPI functions
+// - GKlib utility functions (renamed, e.g., libparmetis__iset)
+// - ParMETIS API definitions (though internal files usually implement, not call, these)
+// - Internal data structures like ctrl_t, graph_t
+// - Internal constants from defs.h
+// - Utility macros from macros.h
+// - Prototypes for other internal ParMETIS functions from proto.h
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   This header is the root of most internal includes. It ensures that all necessary definitions are available and in a consistent order.
+    *   It relies on all the headers it includes (`GKlib.h`, `parmetis.h`, `gklib_defs.h`, `rename.h`, `defs.h`, `struct.h`, `macros.h`, `proto.h`).
+*   **External Libraries**:
+    *   `MPI`: Directly includes `mpi.h`.
+    *   `GKlib`: Includes `GKlib.h`. The ParMETIS build system must provide access to GKlib's headers and potentially its source (if compiled as part of ParMETIS).
+*   **Other Interactions**:
+    *   This file is crucial for compiling the ParMETIS library. Any changes to the set of included files or their order could impact the build.
+    *   The commented-out `DEBUG` and `DMALLOC` macros suggest build-time configurations for development and debugging.
+
+```

--- a/documentation/pometis.c.md
+++ b/documentation/pometis.c.md
@@ -1,0 +1,78 @@
+# programs/pometis.c
+
+## Overview
+
+This file contains the `main` function for the `pometis` command-line executable. This program is specifically designed as a driver for ParMETIS's parallel graph ordering routines, primarily `ParMETIS_V3_NodeND` (and its tunable version `ParMETIS_V32_NodeND`) and `ParMETIS_SerialNodeND`. It allows users to compute fill-reducing orderings for sparse matrices from the command line.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`main(int argc, char *argv[])`**:
+    *   Entry point for the `pometis` executable.
+    *   Initializes MPI.
+    *   **Command-line Argument Parsing**:
+        *   Expects 9 arguments if `optype == 2`, fewer for other optypes.
+            1.  `graph-file`: Name of the file containing the graph.
+            2.  `op-type`: Integer specifying the ordering operation:
+                *   `1`: `ParMETIS_V3_NodeND` (standard parallel nested dissection).
+                *   `2`: `ParMETIS_V32_NodeND` (tunable parallel nested dissection).
+                *   `3`: `ParMETIS_SerialNodeND` (serial nested dissection on PE 0 after graph assembly).
+            3.  `seed`: Random seed.
+            4.  `dbglvl`: Debug level.
+            5.  `mtype` (for `optype == 2`): Matching type (e.g., `PARMETIS_MTYPE_LOCAL`, `PARMETIS_MTYPE_GLOBAL`).
+            6.  `rtype` (for `optype == 2`): Refinement type (e.g., `PARMETIS_SRTYPE_GREEDY`, `PARMETIS_SRTYPE_2PHASE`).
+            7.  `p_nseps` (for `optype == 2`): Number of separators in parallel.
+            8.  `s_nseps` (for `optype == 2`): Number of separators in serial.
+            9.  `ubfrac` (for `optype == 2`): Imbalance fraction for separators.
+    *   Reads the distributed graph using `ParallelReadGraph`.
+    *   Allocates `order` and `sizes` arrays.
+    *   **Operation Dispatch (based on `optype`)**:
+        *   `optype == 1`: Sets up basic `options` (seed, dbglvl) and calls `ParMETIS_V3_NodeND`.
+        *   `optype == 2`: Parses detailed tuning parameters (`mtype`, `rtype`, etc.) and calls `ParMETIS_V32_NodeND`.
+        *   `optype == 3`: Sets `options[0] = 0` (no options passed to ParMETIS internals, defaults used by SerialNodeND) and calls `ParMETIS_SerialNodeND`.
+    *   Writes the computed ordering to a file using `WriteOVector`.
+    *   Prints separator sizes and an "OPC" (Operations Per Cycle, a measure of factorization complexity) estimate based on separator sizes.
+    *   Frees allocated memory and finalizes MPI.
+
+## Important Variables/Constants
+
+*   `optype`: Command-line argument determining which ordering function to call.
+*   `options`: Array for basic options like seed and debug level for `ParMETIS_V3_NodeND`.
+*   `seed`, `dbglvl`, `mtype`, `rtype`, `p_nseps`, `s_nseps`, `ubfrac`: Parameters for the tunable `ParMETIS_V32_NodeND`.
+*   `graph` (graph_t): Stores the distributed graph.
+*   `order` (idx_t *): Stores the computed fill-reducing ordering.
+*   `sizes` (idx_t *): Stores the sizes of the separators and leaf domains from the nested dissection.
+
+## Usage Examples
+
+```bash
+# Command-line execution for ParMETIS_V3_NodeND:
+mpirun -np <num_procs> pometis <graphfile> 1 <seed> <dbglvl>
+
+# Example: Order 'mygraph.graph' using default parallel ND with seed 0, dbglvl 0
+mpirun -np 4 pometis mygraph.graph 1 0 0
+
+# Command-line execution for tunable ParMETIS_V32_NodeND:
+mpirun -np <num_procs> pometis <graphfile> 2 <seed> <dbglvl> <mtype> <rtype> <p_nseps> <s_nseps> <ubfrac>
+
+# Example: Order 'mygraph.graph' using tunable parallel ND
+mpirun -np 4 pometis mygraph.graph 2 0 0 1 2 1 1 1.05
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` and `programs/proto.h`.
+    *   `programs/io.c`: For `ParallelReadGraph`, `WriteOVector`.
+    *   `libparmetis/parmetis.h` (API): Calls `ParMETIS_V3_NodeND`, `ParMETIS_V32_NodeND`.
+    *   `libparmetis/pspases.c`: `ParMETIS_SerialNodeND` is called for `optype == 3`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`.
+    *   Standard C library (stdio, stdlib, string).
+*   **Other Interactions**:
+    *   This program is the primary command-line tool for accessing ParMETIS's parallel graph ordering capabilities.
+    *   The `sizes` array output provides insight into the structure of the nested dissection separator tree, which is important for understanding the quality of the ordering for sparse factorization.
+    *   The "OPC" calculation is a heuristic to estimate the computational cost of factorization using this order.
+
+```

--- a/documentation/programs_io.c.md
+++ b/documentation/programs_io.c.md
@@ -1,0 +1,88 @@
+# programs/io.c
+
+## Overview
+
+This file provides I/O utility functions specifically for the ParMETIS executable programs (drivers/tests like `parmetis`, `mtest`, `ptest`, `otest`). It includes functions to read distributed graphs from files where each processor reads its portion (or PE `npes-1` / PE 0 reads and distributes), read mesh data, read coordinate files, and write partition vectors or ordering vectors to files. It handles both standard METIS graph formats and potentially specialized formats for coordinates or meshes.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParallelReadGraph(graph_t *graph, char *filename, MPI_Comm comm)`**:
+    *   Reads a distributed graph in METIS format.
+    *   PE `npes-1` opens the file, reads header information (global number of vertices, edges, format code, number of constraints `ncon`, number of objectives `nobj`), and broadcasts this information.
+    *   `vtxdist` (vertex distribution) is computed and broadcasted.
+    *   PE `npes-1` then reads the graph line by line. For each vertex line:
+        *   It determines which PE the vertex belongs to based on `vtxdist`.
+        *   It sends the vertex data (degree, weights if any, adjacency list with edge weights if any) to the target PE.
+    *   Other PEs receive their respective data and populate their local `graph_t` structure.
+    *   This method involves significant inter-processor communication as one PE reads and distributes.
+*   **`Mc_ParallelWriteGraph(ctrl_t *ctrl, graph_t *graph, char *filename, idx_t nparts, idx_t testset)`**:
+    *   Writes a distributed graph to a single file in METIS format.
+    *   PE 0 writes the header.
+    *   Then, PEs from 0 to `npes-1` sequentially append their local graph data to the file. This requires careful coordination to ensure correct file access.
+*   **`ReadTestGraph(graph_t *graph, char *filename, MPI_Comm comm)`**:
+    *   Reads a graph in METIS format. PE 0 reads the entire graph using `ReadMetisGraph`.
+    *   `vtxdist` is computed to distribute the graph.
+    *   PE 0 then sends the appropriate portions of `xadj` and `adjncy` to other PEs. Vertex and edge weights are not explicitly handled in this simplified distribution shown (sets `vwgt` and `adjwgt` to `NULL`).
+*   **`ReadTestCoordinates(graph_t *graph, char *filename, idx_t *r_ndims, MPI_Comm comm)`**:
+    *   Reads vertex coordinates from a file.
+    *   PE 0 opens the file, reads the first line to determine `ndims` (number of dimensions), and broadcasts `ndims`.
+    *   PE 0 reads the entire coordinate file and sends the relevant coordinate sets to each PE based on `graph->vtxdist`.
+*   **`ReadMetisGraph(char *filename, idx_t *r_nvtxs, idx_t **r_xadj, idx_t **r_adjncy)`**:
+    *   A serial function to read an entire graph in METIS format (no weights).
+    *   Allocates and returns `xadj` and `adjncy`.
+*   **`Mc_SerialReadGraph(graph_t *graph, char *filename, idx_t *wgtflag, MPI_Comm comm)`**:
+    *   PE 0 reads an entire graph using `Mc_SerialReadMetisGraph` (which supports weights).
+    *   Graph metadata (`ncon`, `nobj`, `fmt`, `wgtflag`, `vtxdist`) is broadcast.
+    *   PE 0 then distributes the graph data (`xadj`, `vwgt`, `adjncy`, `adjwgt`) to other PEs.
+*   **`Mc_SerialReadMetisGraph(char *filename, idx_t *r_nvtxs, ..., idx_t *wgtflag)`**:
+    *   A detailed serial function to read a METIS graph file, parsing the format line to understand if vertex weights (`readvw`) and/or edge weights (`readew`) are present, and also reads `ncon` and `nobj` if specified.
+    *   Allocates and returns all graph arrays.
+*   **`WritePVector(char *gname, idx_t *vtxdist, idx_t *part, MPI_Comm comm)`**:
+    *   Writes a distributed partition vector `part` to a file named `<gname>.part`.
+    *   PE 0 gathers the partition vector segments from all other PEs via `MPI_Recv` (others `MPI_Send`) and writes them sequentially.
+*   **`WriteOVector(char *gname, idx_t *vtxdist, idx_t *order, MPI_Comm comm)`**:
+    *   Writes a distributed ordering vector `order` to a file named `<gname>.order.<npes>`.
+    *   Similar to `WritePVector`, PE 0 gathers and writes. It also includes a check on PE 0 to ensure the received global ordering is a valid permutation.
+*   **`ParallelReadMesh(mesh_t *mesh, char *filename, MPI_Comm comm)`**:
+    *   Reads a distributed mesh from a file.
+    *   PE `npes-1` reads the header (number of elements, element type), broadcasts it.
+    *   `elmdist` is computed and broadcast.
+    *   PE `npes-1` reads element connectivity line by line and sends to the appropriate PE.
+    *   Node IDs are normalized (global 0-based).
+
+## Important Variables/Constants
+
+*   **`MAXLINE`**: Defines a large buffer size (e.g., 64MB) for `fgets`, anticipating potentially very long lines if many adjacencies or weights are on one line in the METIS graph format.
+*   Format variables (`fmt`, `readew`, `readvw`, `ncon`, `nobj`): Parsed from graph file headers to determine how to read weights and other parameters.
+
+## Usage Examples
+
+```c
+// In a ParMETIS test program (e.g., parmetis.c):
+// graph_t graph;
+// ParallelReadGraph(&graph, filename, comm); // Reads the input graph
+// ...
+// idx_t *part = imalloc(graph.nvtxs, "partition_vector");
+// ParMETIS_V3_PartKway(graph.vtxdist, graph.xadj, ..., part, ...);
+// ...
+// WritePVector(filename, graph.vtxdist, part, comm); // Writes the resulting partition
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` (for `graph_t`, `mesh_t`, `ctrl_t`, `idx_t`, MPI wrappers, GKlib utilities) and `programs/proto.h`.
+    *   `parmetislib.h` (indirectly): Provides `ismalloc`, `imalloc`, `rmalloc`, `gk_cmalloc`, `gk_free`, `MAKECSR`, `icopy`, `strtoidx`, `strtoreal`, `GlobalSESum`, `errexit`, `imin`, `imax`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for communication in all parallel read/write functions.
+    *   Standard C library: For file I/O (`fopen`, `fgets`, `sscanf`, `fprintf`, `fclose`), string manipulation (`strlen`), memory operations (`memcpy`).
+*   **Other Interactions**:
+    *   These I/O functions are crucial for the ParMETIS test programs to load graph/mesh data and save results.
+    *   The parallel reading strategies vary:
+        *   `ParallelReadGraph` and `ParallelReadMesh`: One PE reads and sends lines/data to others.
+        *   `ReadTestGraph`, `ReadTestCoordinates`, `Mc_SerialReadGraph`: PE 0 reads everything, then scatters data.
+    *   Writing is generally done by PE 0 gathering data from other PEs.
+
+```

--- a/documentation/programs_proto.h.md
+++ b/documentation/programs_proto.h.md
@@ -1,0 +1,68 @@
+# programs/proto.h
+
+## Overview
+
+This header file contains function prototypes for routines defined within the `programs` directory of ParMETIS. These routines are typically part of the test drivers, command-line executables, or I/O utilities specific to these programs, rather than being part of the core ParMETIS library itself. This file allows different `.c` files within the `programs` directory to call each other's functions.
+
+## Key Components
+
+This file consists almost entirely of function prototype declarations.
+
+### Categories of Prototypes (based on typical ParMETIS program structure):
+
+*   **I/O Functions (likely from `programs/io.c`)**:
+    *   `ParallelReadGraph(graph_t *, char *, MPI_Comm)`: Reads a distributed graph.
+    *   `Mc_ParallelWriteGraph(ctrl_t *, graph_t *, char *, idx_t, idx_t)`: Writes a distributed graph.
+    *   `ReadTestGraph(graph_t *, char *, MPI_Comm)`: Reads a graph with PE 0 doing most work.
+    *   `ReadTestCoordinates(graph_t *, char *, idx_t *, MPI_Comm)`: Reads vertex coordinates.
+    *   `ReadMetisGraph(char *, idx_t *, idx_t **, idx_t **)`: Serial METIS graph reader.
+    *   `Mc_SerialReadGraph(graph_t *, char *, idx_t *, MPI_Comm)`: PE 0 reads, then distributes.
+    *   `Mc_SerialReadMetisGraph(char *, idx_t *, idx_t *, idx_t *, idx_t *, idx_t **, idx_t **, idx_t **, idx_t **, idx_t *)`: Detailed serial METIS graph reader.
+    *   `WritePVector(char *gname, idx_t *vtxdist, idx_t *part, MPI_Comm comm)`: Writes a partition vector.
+    *   `WriteOVector(char *gname, idx_t *vtxdist, idx_t *order, MPI_Comm comm)`: Writes an ordering vector.
+*   **Graph Adaptation Functions (likely from `programs/adaptgraph.c`)**:
+    *   `AdaptGraph(graph_t *, idx_t, MPI_Comm)`: Adapts graph vertex weights.
+    *   `AdaptGraph2(graph_t *, idx_t, MPI_Comm)`: Another variant of graph adaptation.
+    *   `Mc_AdaptGraph(graph_t *, idx_t *, idx_t, idx_t, MPI_Comm)`: Multi-constraint graph adaptation.
+*   **Test Program Main Logic (e.g., from `ptest.c`, `otest.c`)**:
+    *   `TestParMetis_GPart(char *filename, char *xyzfile, MPI_Comm comm)`: (Prototype might be slightly different in actual `ptest.c` or `otest.c` regarding `xyzfile`). A main test function. The `otest.c` version is `void TestParMetis(char *filename, MPI_Comm comm)`.
+    *   `ComputeRealCut(idx_t *, idx_t *, char *, MPI_Comm)`: Computes edge cut by gathering partition and reading graph on PE 0.
+    *   `ComputeRealCutFromMoved(idx_t *, idx_t *, idx_t *, idx_t *, char *, MPI_Comm)`: Computes cut involving a moved graph's partition. (The actual name in `otest.c` is `ComputeRealCut2`).
+    *   `TestMoveGraph(graph_t *, graph_t *, idx_t *, MPI_Comm)`: Utility to test graph movement.
+    *   `TestSetUpGraph(ctrl_t *, idx_t *, idx_t *, idx_t *, idx_t *, idx_t *, idx_t)`: (Likely an older or internal setup utility for tests, seen in `otest.c` as just `SetUpGraph`).
+*   **Mesh I/O (likely from `programs/meshio.c` or similar, though not explicitly in current file list beyond `mtest.c` using `ParallelReadMesh`)**:
+    *   `mienIO(mesh_t *, char *, idx_t, idx_t, MPI_Comm)`: (Purpose less clear without seeing `mienio.c`, possibly specialized mesh I/O).
+    *   `ParallelReadMesh(mesh_t *, char *, MPI_Comm)`: Reads a distributed mesh.
+
+## Important Variables/Constants
+
+This file only contains function declarations. It relies on types like `graph_t`, `ctrl_t`, `mesh_t`, `idx_t`, `real_t`, `MPI_Comm` being defined in headers included via `parmetisbin.h` (which includes `parmetislib.h`).
+
+## Usage Examples
+
+```c
+// This is a header file. It's included by parmetisbin.h, which is then
+// included by .c files in the programs directory (e.g., parmetis.c, otest.c).
+
+// Example: In parmetis.c
+// #include <parmetisbin.h> // This will include programs/proto.h
+// ...
+// graph_t graph;
+// ParallelReadGraph(&graph, argv[1], comm); // Call to function prototyped in programs/proto.h
+// ...
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies (programs directory)**:
+    *   This file is included by `parmetisbin.h`.
+    *   It declares functions that are implemented in other `.c` files within the `programs` directory (e.g., `io.c`, `adaptgraph.c`).
+*   **Internal Dependencies (ParMETIS library)**:
+    *   Many function signatures use types defined in the ParMETIS library (e.g., `graph_t`, `ctrl_t`, `mesh_t`, `idx_t`).
+*   **External Libraries**:
+    *   `MPI`: MPI types like `MPI_Comm` are used in function signatures.
+*   **Other Interactions**:
+    *   This file enables modularity within the `programs` directory, allowing different test programs or utilities to share common functions like I/O routines.
+    *   It provides a quick reference to the helper functions available specifically for the ParMETIS executables.
+
+```

--- a/documentation/proto.h.md
+++ b/documentation/proto.h.md
@@ -1,0 +1,85 @@
+# libparmetis/proto.h
+
+## Overview
+
+This header file serves as a central repository for function prototypes of internal routines within the ParMETIS library. Its primary purpose is to declare the signatures of functions defined in various `.c` files in the `libparmetis` directory, allowing these functions to be called across different modules/files while ensuring type safety and enabling compilation.
+
+## Key Components
+
+This file consists almost entirely of function prototype declarations. These prototypes are organized by the source file in which the corresponding functions are implemented.
+
+### Categories of Prototypes (based on source file comments):
+
+*   **`ctrl.c`**: Functions for managing the `ctrl_t` control structure (e.g., `SetupCtrl`, `FreeCtrl`).
+*   **`kmetis.c`**: Core k-way partitioning logic (e.g., `Global_Partition`).
+*   **`mmetis.c`**: (No prototypes listed, likely API functions or static internal helpers).
+*   **`gkmetis.c`**: (No prototypes listed, likely API functions or static internal helpers).
+*   **`match.c`**: Graph matching algorithms for coarsening (e.g., `Match_Global`, `Match_Local`, `CreateCoarseGraph_Global`, `CreateCoarseGraph_Local`, `DropEdges`).
+*   **`initpart.c`**: Initial partitioning routines (e.g., `InitPartition`, `KeepPart`).
+*   **`kwayrefine.c`**: K-way refinement algorithms (e.g., `ProjectPartition`, `ComputePartitionParams`, `KWayFM`, `KWayBalance`).
+*   **`remap.c`**: Functions for remapping graphs or partitions (e.g., `ParallelReMapGraph`).
+*   **`move.c`**: Functions for moving graph data based on partitions (e.g., `MoveGraph`, `ProjectInfoBack`, `FindVtxPerm`).
+*   **`wspace.c`**: Workspace memory management (e.g., `AllocateWSpace`, `wspacemalloc`).
+*   **`ametis.c`**: Adaptive repartitioning (e.g., `Adaptive_Partition`).
+*   **`rmetis.c`**: (No prototypes listed, likely API functions or static internal helpers).
+*   **`wave.c`**: Wavefront diffusion algorithm (e.g., `WavefrontDiffusion`).
+*   **`balancemylink.c`**: Balancing between two partitions (e.g., `BalanceMyLink`).
+*   **`redomylink.c`**: Another routine for balancing/refining a link (e.g., `RedoMyLink`).
+*   **`initbalance.c`**: Initial balancing routines (e.g., `Balance_Partition`, `AssembleAdaptiveGraph`).
+*   **`mdiffusion.c`**: Multi-constraint diffusion (e.g., `Mc_Diffusion`, `ExtractGraph`).
+*   **`diffutil.c`**: Utilities for diffusion (e.g., `SetUpConnectGraph`, `Mc_ComputeMoveStatistics`, `ConjGrad2`).
+*   **`akwayfm.c`**: Adaptive k-way FM refinement (e.g., `KWayAdaptiveRefine`).
+*   **`selectq.c`**: Queue selection utilities for refinement (e.g., `Mc_DynamicSelectQueue`, `Mc_HashVwgts`).
+*   **`csrmatch.c`**: CSR-based matching (e.g., `CSR_Match_SHEM`).
+*   **`serial.c`**: Serial graph operations used within parallel context (e.g., `Mc_ComputeSerialPartitionParams`, `Mc_SerialKWayAdaptRefine`).
+*   **`weird.c`**: Input checking routines for API functions (e.g., `CheckInputsPartKway`, `CheckInputsNodeND`). Also `PartitionSmallGraph`.
+*   **`mesh.c`**: (No prototypes listed, API function `ParMETIS_V3_Mesh2Dual` is declared in `parmetis.h`).
+*   **`pspases.c`**: Routines for PSPASES compatibility (e.g., `AssembleEntireGraph`).
+*   **`node_refine.c`**: Node-based separator refinement (e.g., `AllocateNodePartitionParams`, `KWayNodeRefine_Greedy`).
+*   **`initmsection.c`**: Initial multisection routines (e.g., `InitMultisection`, `AssembleMultisectedGraph`).
+*   **`ometis.c`**: Ordering routines (e.g., `MultilevelOrder`, `Order_Partition`, `LabelSeparators`, `CompactGraph`, `LocalNDOrder`).
+*   **`xyzpart.c`**: Geometric partitioning based on coordinates (e.g., `Coordinate_Partition`).
+*   **`stat.c`**: Statistics computation (e.g., `ComputeSerialBalance`, `ComputeParallelBalance`, `PrintPostPartInfo`).
+*   **`debug.c`**: Debugging print functions (e.g., `PrintVector`, `PrintGraph`).
+*   **`comm.c`**: Low-level communication utilities (e.g., `CommSetup`, `CommInterfaceData`, `GlobalSESum`).
+*   **`util.c`**: General utility functions (e.g., `myprintf`, `BSearch`, `RandomPermute`).
+*   **`graph.c`**: Graph data structure management (e.g., `SetupGraph`, `FreeGraph`).
+*   **`renumber.c`**: Graph renumbering utilities (e.g., `ChangeNumbering`).
+*   **`timer.c`**: Timer initialization and printing (e.g., `InitTimers`, `PrintTimingInfo`).
+*   **`parmetis.c`**: (Likely refers to the file containing API entry points or Fortran interface helpers like `ChangeToFortranNumbering`).
+*   **`msetup.c`**: Mesh setup routines (e.g., `SetUpMesh`).
+*   **`gkmpi.c`**: Wrappers for MPI calls (e.g., `gkMPI_Comm_size`, `gkMPI_Allreduce`).
+
+## Important Variables/Constants
+
+This file primarily contains function declarations. It does not define variables or constants itself, but relies on types like `ctrl_t`, `graph_t`, `idx_t`, `real_t`, `ikv_t`, `matrix_t`, `mesh_t`, `MPI_Comm`, `pmoptype_et` which are defined in other headers included via `parmetislib.h`.
+
+## Usage Examples
+
+```c
+// This is a header file. It's included by parmetislib.h, which is then
+// included by most .c files in the ParMETIS library.
+
+// Example: In kmetis.c
+// #include <parmetislib.h> // This will include proto.h
+// ...
+// void Global_Partition(ctrl_t *ctrl, graph_t *graph) {
+//   ...
+//   Match_Global(ctrl, graph); // Call to function prototyped in proto.h (implemented in match.c)
+//   ...
+// }
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   This file is included by `parmetislib.h`.
+    *   It depends on `ctrl_t`, `graph_t`, `idx_t`, `real_t`, `ikv_t`, `matrix_t`, `mesh_t`, `MPI_Comm`, `pmoptype_et` and other types being defined in headers like `struct.h` and `parmetis.h` (which are included before `proto.h` via `parmetislib.h`).
+    *   The actual implementations of these prototyped functions are spread across numerous `.c` files in the `libparmetis` directory.
+*   **External Libraries**:
+    *   `MPI`: Some prototypes involve MPI types like `MPI_Comm`.
+*   **Other Interactions**:
+    *   This file is essential for modular compilation of the ParMETIS library, allowing different `.c` files to call functions defined in others.
+    *   It provides a quick overview of the internal functions available within the library and their parameters.
+
+```

--- a/documentation/pspases.c.md
+++ b/documentation/pspases.c.md
@@ -1,0 +1,73 @@
+# libparmetis/pspases.c
+
+## Overview
+
+This file contains routines specifically designed for interfacing ParMETIS with PSPASES, a parallel sparse direct solver library. The primary function `ParMETIS_SerialNodeND` provides a nested dissection ordering by first assembling the entire distributed graph onto a single processor (PE 0) and then calling the serial METIS nested dissection routine (`METIS_NodeNDP`) on it. The resulting ordering and separator sizes are then scattered back to all processors.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_SerialNodeND(idx_t *vtxdist, idx_t *xadj, idx_t *adjncy, idx_t *numflag, idx_t *options, idx_t *order, idx_t *sizes, MPI_Comm *comm)`**:
+    *   This is an API-level function, likely intended for use when a serial nested dissection ordering of the entire graph is desired, possibly for comparison or when PSPASES is used in a mode that benefits from such an ordering.
+    *   **Functionality**:
+        1.  Sets up a ParMETIS control structure (`ctrl_t`).
+        2.  Checks if the number of processors (`npes`) is a power of 2, which is a requirement for `METIS_NodeNDP`.
+        3.  If `numflag > 0` (1-based input), converts graph numbering to 0-based (`ChangeNumbering`).
+        4.  Calls `AssembleEntireGraph` to gather the full distributed graph onto PE 0. The assembled graph is `agraph`.
+        5.  **On PE 0 only**:
+            *   Allocates `perm` and `iperm` arrays for the ordering.
+            *   Calls `METIS_NodeNDP` (a METIS function, possibly specialized for creating orderings suitable for PSPASES or that outputs `npes` separator sizes) on `agraph` to compute the nested dissection ordering (`iperm`) and separator tree structure (`sizes`).
+        6.  Broadcasts the `sizes` array from PE 0 to all other processors.
+        7.  Scatters the computed ordering (`iperm` from PE 0) to the `order` array on each processor, distributing the relevant portions based on `vtxdist`.
+        8.  Frees allocated memory.
+        9.  If `numflag > 0`, converts the `order` array back to 1-based numbering.
+*   **`AssembleEntireGraph(ctrl_t *ctrl, idx_t *vtxdist, idx_t *xadj, idx_t *adjncy)`**:
+    *   Gathers the entire distributed graph (CSR structure: `xadj` and `adjncy`) onto processor 0.
+    *   **Steps**:
+        1.  Each processor first sends its local `xadj` degree counts to PE 0 using `gkMPI_Gatherv`. PE 0 reconstructs the global `axadj` (CSR row pointers for the assembled graph).
+        2.  Each processor sends its local `adjncy` (adjacency lists) to PE 0 using `gkMPI_Gatherv`. PE 0 reconstructs the global `aadjncy`.
+    *   Returns a `graph_t` structure (`agraph`) on PE 0 containing the assembled graph. On other PEs, `agraph` might be created but would not contain the full graph data. (Note: The implementation seems to allocate `axadj` and `aadjncy` on all PEs but only PE0 fills them with the full graph).
+
+## Important Variables/Constants
+
+*   **`agraph` (graph_t)**: Graph structure holding the entire assembled graph, primarily on PE 0.
+*   **`perm`, `iperm` (in `ParMETIS_SerialNodeND` on PE 0)**: Permutation and inverse permutation arrays for the nested dissection ordering. `iperm` stores the actual ordering.
+*   **`sizes` (output of `ParMETIS_SerialNodeND`)**: Array storing the sizes of the separators in the nested dissection tree, as defined by `METIS_NodeNDP`.
+*   **`order` (output of `ParMETIS_SerialNodeND`)**: Array storing the segment of the global ordering relevant to each PE.
+
+## Usage Examples
+
+```c
+// Conceptual call to ParMETIS_SerialNodeND
+// (assuming vtxdist, xadj, adjncy, order, sizes, comm are set up)
+// idx_t numflag = 0;
+// idx_t options[METIS_NOPTIONS]; options[0] = 0; // Default options
+//
+// ParMETIS_SerialNodeND(vtxdist, xadj, adjncy, &numflag, options,
+//                       order, sizes, &comm);
+//
+// // 'order' now contains the fill-reducing permutation computed serially on PE 0
+// // and distributed.
+// // 'sizes' contains the separator tree sizes.
+```
+This is an API function, potentially used in conjunction with the PSPASES solver.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions.
+    *   `ctrl.c`: For `SetupCtrl`, `FreeCtrl`.
+    *   `graph.c`: For `CreateGraph`.
+    *   `util.c`: For `ChangeNumbering`.
+    *   `gkmpi.c`: For MPI wrappers like `gkMPI_Gatherv`, `gkMPI_Bcast`, `gkMPI_Scatterv`.
+    *   `metis.h` (external METIS library): `METIS_NodeNDP` is the core serial ordering routine used on PE 0.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for gathering the graph and distributing the results.
+    *   `METIS`: The serial METIS library is essential for the actual nested dissection ordering.
+*   **Other Interactions**:
+    *   This function provides a way to obtain a serial nested dissection ordering for a distributed graph, which might be required by certain modes of operation of parallel direct solvers like PSPASES or for comparison purposes.
+    *   The requirement that `npes` must be a power of 2 is a specific constraint imposed by `METIS_NodeNDP`.
+    *   The majority of the computational work (graph assembly and ordering) happens on PE 0, making it a bottleneck for very large graphs.
+
+```

--- a/documentation/ptest.c.md
+++ b/documentation/ptest.c.md
@@ -1,0 +1,99 @@
+# programs/ptest.c
+
+## Overview
+
+This file is a test driver program for ParMETIS, named `ptest`. It's very similar in structure and purpose to `otest.c`. It's designed to test a comprehensive suite of ParMETIS V3 API functions, including k-way partitioning (`ParMETIS_V3_PartKway`), geometric k-way partitioning (`ParMETIS_V3_PartGeomKway`), geometric partitioning based on coordinates (`ParMETIS_V3_PartGeom`), k-way partition refinement (`ParMETIS_V3_RefineKway`), and adaptive repartitioning (`ParMETIS_V3_AdaptiveRepart`). It does *not* explicitly test the node nested dissection ordering functions (`ParMETIS_V3_NodeND`) like `otest.c` does.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`main(int argc, char *argv[])`**:
+    *   Entry point for the `ptest` program.
+    *   Initializes MPI.
+    *   Requires one or two command-line arguments:
+        1.  `graph-file`: The name of the graph file.
+        2.  `coord-file` (optional): The name of the vertex coordinates file.
+    *   Calls `TestParMetis_GPart` to run the actual tests.
+    *   Finalizes MPI.
+*   **`TestParMetis_GPart(char *filename, char *xyzfile, MPI_Comm comm)`**:
+    *   The main testing logic. (Note: This function has the same name as the one in `otest.c` but the content of `otest.c`'s `TestParMetis` is more comprehensive. This version in `ptest.c` might be an older or slightly different variant).
+    *   Reads the graph using `ParallelReadGraph`.
+    *   If `xyzfile` is provided, reads coordinates using `ReadTestCoordinates`.
+    *   Initializes `vwgt` with dummy weights (all 1s, or adapted weights for multi-constraint tests).
+    *   **Tests `ParMETIS_V3_PartKway`**:
+        *   Iterates through different numbers of partitions (`nparts` from `2*npes` down to `npes/2`).
+        *   Iterates through number of constraints (`ncon` from 1 up to `NCON` (defined as 5)).
+        *   If `ncon > 1`, calls `Mc_AdaptGraph` to create varying vertex weights.
+        *   Calls `ParMETIS_V3_PartKway`.
+        *   Computes the actual cut using `ComputeRealCut` and compares it with the cut reported by ParMETIS.
+    *   **Tests `ParMETIS_V3_RefineKway` (Uncoupled)**:
+        *   After each `PartKway` test, it immediately tests `RefineKway` on that result with `options[3] = PARMETIS_PSR_UNCOUPLED`.
+    *   **Tests `ParMETIS_V3_PartGeomKway`**:
+        *   If `xyzfile` was provided, runs similar loops for `nparts` and `ncon` as for `PartKway`.
+        *   Calls `ParMETIS_V3_PartGeomKway`.
+        *   Compares reported cut with `ComputeRealCut`.
+    *   **Tests `ParMETIS_V3_PartGeom`**:
+        *   If `xyzfile` was provided.
+        *   Calls `ParMETIS_V3_PartGeom`.
+        *   Computes and prints the cut using `ComputeRealCut`.
+    *   **Tests `ParMETIS_V3_RefineKway` (Coupled, after graph move)**:
+        1.  Partitions the graph using `PartKway` (quietly) to get an `npes`-way partition.
+        2.  Moves the graph using `TestMoveGraph` to create `mgraph`.
+        3.  Iterates `ncon` from 1 to `NCON`.
+        4.  Calls `ParMETIS_V3_RefineKway` on `mgraph` with `options[3] = PARMETIS_PSR_COUPLED`.
+        5.  Computes cut using `ComputeRealCutFromMoved` and compares.
+    *   **Tests `ParMETIS_V3_AdaptiveRepart`**:
+        1.  Uses `mgraph`. Adapts its vertex weights using `AdaptGraph` (for `ncon=1`) or `Mc_AdaptGraph` (for `ncon>1`).
+        2.  First, partitions `mgraph` with `PartKway` to get a base partition (`savepart`).
+        3.  Iterates `nparts`, `ncon`, and `ipc2redist` values.
+        4.  Calls `ParMETIS_V3_AdaptiveRepart` using `savepart` as the initial state for `mpart`.
+        5.  Computes cut using `ComputeRealCutFromMoved` and compares.
+*   **`ComputeRealCut(idx_t *vtxdist, idx_t *part, char *filename, MPI_Comm comm)`**:
+    *   (Identical to the one in `otest.c`) Gathers the distributed partition vector `part` onto PE 0. PE 0 reads the original graph (serially using `ReadMetisGraph`) and computes the actual edge cut.
+*   **`ComputeRealCutFromMoved(idx_t *vtxdist, idx_t *mvtxdist, idx_t *part, idx_t *mpart, char *filename, MPI_Comm comm)`**:
+    *   (Identical to `ComputeRealCut2` in `otest.c`) Computes the cut of an original graph based on a partition (`mpart`) of a moved graph. It reconstructs the permutation from the original `part` (which led to the move) to map vertices correctly.
+*   **`TestMoveGraph(graph_t *ograph, graph_t *omgraph, idx_t *part, MPI_Comm comm)`**:
+    *   (Identical to the one in `otest.c`) A wrapper to test `MoveGraph` from `libparmetis`.
+*   **`TestSetUpGraph(ctrl_t *ctrl, idx_t *vtxdist, ..., idx_t wgtflag)`**:
+    *   (Identical to `SetUpGraph` in `otest.c`) An older/internal style graph setup wrapper.
+
+## Important Variables/Constants
+
+*   `NCON`: Defined as 5, the maximum number of constraints tested in loops.
+*   `graph` (graph_t): Holds the primary distributed graph.
+*   `mgraph` (graph_t): Holds the "moved" graph after redistribution.
+*   `part`, `mpart`, `savepart`: Arrays for storing partitioning results.
+*   `xyz`: Array for vertex coordinates.
+*   `options`: Array to control ParMETIS behavior.
+*   `MAXNCON`: Used for allocating `tpwgts` and `ubvec`.
+
+## Usage Examples
+
+```bash
+# Command-line execution:
+mpirun -np <num_procs> ptest <graph_file_name> [coord_file_name]
+
+# Example:
+mpirun -np 4 ptest mygraph.graph mygraph.xyz
+# This would partition mygraph.graph (using its coordinates from mygraph.xyz where applicable)
+# using various ParMETIS routines and parameters.
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetisbin.h`: Includes `parmetislib.h` and `programs/proto.h`.
+    *   `programs/io.c`: For `ParallelReadGraph`, `ReadTestCoordinates`, `ReadMetisGraph`.
+    *   `programs/adaptgraph.c`: For `AdaptGraph`, `Mc_AdaptGraph`.
+    *   `libparmetis/parmetis.h` (API): Calls `ParMETIS_V3_PartKway`, `ParMETIS_V3_PartGeomKway`, `ParMETIS_V3_PartGeom`, `ParMETIS_V3_RefineKway`, `ParMETIS_V3_AdaptiveRepart`.
+    *   `libparmetis` (internal functions): Uses `SetupCtrl`, `MoveGraph`, `FreeGraph`, etc. (Some via local wrappers like `TestMoveGraph` and `TestSetUpGraph`).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`.
+    *   Standard C library.
+*   **Other Interactions**:
+    *   `ptest.c` is a comprehensive test driver focusing on partitioning and refinement APIs. Unlike `otest.c`, it does not explicitly include tests for `ParMETIS_V3_NodeND`.
+    *   It systematically varies parameters like `nparts`, `ncon`, and some `options` to cover a range of scenarios.
+    *   The `ComputeRealCut` functions are important for verifying the edge cut reported by ParMETIS against a value computed from the full, gathered graph structure.
+
+```

--- a/documentation/redomylink.c.md
+++ b/documentation/redomylink.c.md
@@ -1,0 +1,72 @@
+# libparmetis/redomylink.c
+
+## Overview
+
+This file contains the `RedoMyLink` function, which appears to be a specialized 2-way refinement/balancing routine. It's similar in purpose to `BalanceMyLink` (found in `balancemylink.c` and also duplicated in `mdiffusion.c`), aiming to improve the partition between two specific subdomains (`me` and `you`) based on `flows` (imbalance). It tries multiple random initial bisections and refines them using serial METIS-like FM refinement and balancing steps, ultimately selecting the best outcome based on cost and load balance.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`RedoMyLink(ctrl_t *ctrl, graph_t *graph, idx_t *home, idx_t me, idx_t you, real_t *flows, real_t *sr_cost, real_t *sr_lbavg)`**:
+    *   Performs a 2-way refinement/balancing between specified partitions `me` and `you`.
+    *   **Parameters**:
+        *   `ctrl`: Control structure.
+        *   `graph`: The graph to operate on. Assumed to contain only vertices belonging to `me` or `you`.
+        *   `home`: Original partition assignments for vertices in `graph`.
+        *   `me`, `you`: The two partitions being balanced.
+        *   `flows`: Input array representing the imbalance for each constraint that needs to be corrected.
+        *   `sr_cost` (output): The cost (cut + redistribution) of the best partition found.
+        *   `sr_lbavg` (output): The load balance average of the best partition found.
+    *   **Functionality**:
+        1.  Initializes workspace and data structures, including temporary `where` arrays (`costwhere`, `lbwhere`) to store the best partitions found according to cost and load balance, respectively.
+        2.  Calculates target partition weights (`tpwgts`) for the 2-way problem based on current actual weights (`pwgts`) and the input `flows`.
+        3.  Performs `N_MOC_REDO_PASSES` iterations:
+            *   In each pass, it creates a random initial bisection of the input `graph` (by assigning one randomly chosen vertex to partition 0, others to 1, which are then mapped to `me` and `you`).
+            *   Calls `Mc_Serial_Compute2WayPartitionParams` to set up parameters for the 2-way problem.
+            *   Calls `Mc_Serial_Init2WayBalance` to perform initial balancing towards `tpwgts`.
+            *   Calls `Mc_Serial_FM_2WayRefine` (an FM-like refinement) multiple times.
+            *   Calls `Mc_Serial_Balance2Way` to further improve balance.
+            *   Calculates the resulting load balance (`lbavg`) and cost (`mycost` = `ipc_factor * cut + redist_factor * total_moved_volume`).
+            *   Updates `bestcost`, `other_lbavg`, `costwhere` if `mycost` is better.
+            *   Updates `best_lbavg`, `othercost`, `lbwhere` if `lbavg` is better.
+        4.  After all passes, it selects between `costwhere` and `lbwhere`. If the balance achieved by `costwhere` (`other_lbavg`) is very good (e.g., <= 0.05), it chooses `costwhere`. Otherwise, it chooses `lbwhere` (which prioritized balance).
+        5.  Copies the selected partition into `graph->where`.
+        6.  Sets output parameters `*sr_cost` and `*sr_lbavg`.
+
+## Important Variables/Constants
+
+*   **`me`, `you`**: The two partitions involved.
+*   **`flows`**: Input array indicating the imbalance to be corrected.
+*   **`home`**: Array of original partition assignments.
+*   **`costwhere`, `lbwhere`**: Temporary arrays to store the partition vectors that yielded the best cost and best load balance, respectively.
+*   **`tpwgts`**: Target partition weights for the 2-way problem.
+*   **`ipc_factor`, `redist_factor`**: From `ctrl`, used in cost calculation.
+*   **`N_MOC_REDO_PASSES`**: Constant from `defs.h` defining the number of refinement attempts.
+
+## Usage Examples
+
+```
+N/A
+```
+This is an internal ParMETIS function. It's likely called by higher-level diffusion or refinement algorithms (e.g., `Mc_Diffusion`) when a specific link (pair of partitions) needs its balance and cut characteristics improved. The calling function would typically extract the subgraph relevant to partitions `me` and `you` before calling `RedoMyLink`.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants.
+    *   `serial.c`: This function heavily relies on serial 2-way refinement and balancing routines:
+        *   `Mc_Serial_Compute2WayPartitionParams`
+        *   `Mc_Serial_Init2WayBalance`
+        *   `Mc_Serial_FM_2WayRefine`
+        *   `Mc_Serial_Balance2Way`
+    *   `util.c`: For `RandomPermute`.
+    *   GKlib utilities: For memory allocation (`iwspacemalloc`, `rwspacemalloc`, `rset`, `iset`, `icopy`) and array operations (`isum`, `ravg`).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Only `gkMPI_Comm_rank` is called, and its result `mype` is not used in the logic, suggesting this function operates on data assumed to be entirely local (e.g., on an extracted subgraph).
+*   **Other Interactions**:
+    *   Modifies `graph->where` with the refined 2-way partition.
+    *   The function attempts multiple random starts to avoid getting stuck in poor local minima.
+    *   The choice between the best-cost and best-balance solutions introduces a heuristic to favor balance unless the cost-optimized solution is already very well-balanced.
+
+```

--- a/documentation/remap.c.md
+++ b/documentation/remap.c.md
@@ -1,0 +1,62 @@
+# libparmetis/remap.c
+
+## Overview
+
+This file contains functions related to remapping partitions to processors, primarily to minimize data redistribution costs. When a k-way partition is computed, the initial assignment of partition numbers (0 to k-1) to physical processor ranks (0 to P-1, where k=P) might not be optimal in terms of how much data needs to move if the graph was already distributed. These functions try to find a permutation of this assignment to reduce total data movement.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParallelReMapGraph(ctrl_t *ctrl, graph_t *graph)`**:
+    *   This function orchestrates the remapping process if the number of processors (`ctrl->npes`) equals the number of partitions (`ctrl->nparts`).
+    *   It calculates `lpwgts`: the sum of `vsize` (or 1 if `vsize` is NULL) of local vertices currently assigned to each partition.
+    *   Calls `ParallelTotalVReMap` to compute the optimal mapping (`map` array).
+    *   Updates `graph->where` by applying the computed `map` to existing partition assignments (`where[i] = map[where[i]]`).
+*   **`ParallelTotalVReMap(ctrl_t *ctrl, idx_t *lpwgts, idx_t *map, idx_t npasses, idx_t ncon)`**:
+    *   Computes an optimal assignment of partitions to processors to minimize total data movement (total volume).
+    *   It assumes `nparts == npes`.
+    *   **Algorithm**:
+        1.  Initializes `map` (partition-to-PE mapping) to -1 (unassigned) and `rowmap` (PE-to-partition mapping) to -1.
+        2.  Iterates for `npasses` or until all partitions are mapped:
+            *   Each processor `mype` identifies its local partition `maxipwgt` that currently holds the most local data (from `mylpwgts`, a copy of `lpwgts`).
+            *   It proposes to map this local partition `maxipwgt` to itself (`mype`), sending a pair `(-mylpwgts[maxipwgt], mype*nparts+maxipwgt)` to all PEs. The negative weight is for sorting to pick heaviest.
+            *   All PEs gather these proposals (`gkMPI_Allgather` into `recv` array).
+            *   Proposals are sorted by weight (heaviest first).
+            *   Iterates through sorted proposals: If partition `j` (proposed by PE `k`) is unmapped (`map[j] == -1`) and PE `k` is unassigned (`rowmap[k] == -1`), and their target partition weights (`ctrl->tpwgts`) are "similar" (`SimilarTpwgts`), then assign `map[j] = k` and `rowmap[k] = j`. Mark `mylpwgts[j] = 0` on the PE that originally held it to prevent re-proposing.
+        3.  If any partitions remain unmapped after the passes (due to `tpwgts` dissimilarity perhaps), they are assigned greedily.
+        4.  Calculates the total data saved by this remapping. If no savings (or negative savings), it reverts `map` to the identity mapping (`map[i] = i`).
+*   **`SimilarTpwgts(real_t *tpwgts, idx_t ncon, idx_t s1, idx_t s2)`**:
+    *   Checks if the target partition weights (`tpwgts`) for two partitions (or PEs, as `nparts==npes`) `s1` and `s2` are similar enough (within `SMALLFLOAT` for all constraints).
+    *   Returns 1 if similar, 0 otherwise. This is used in `ParallelTotalVReMap` to ensure that a partition `j` is only mapped to a processor `k` if their target workloads are compatible.
+
+## Important Variables/Constants
+
+*   **`map` (in `ParallelTotalVReMap`, output to `ParallelReMapGraph`)**: An array of size `nparts`. `map[i] = j` means original partition `i` should be remapped to new partition ID `j` (which corresponds to PE `j`).
+*   **`lpwgts` (in `ParallelTotalVReMap`)**: Array storing the amount of data each PE has for each partition.
+*   **`rowmap` (in `ParallelTotalVReMap`)**: Temporary array, `rowmap[k] = j` means PE `k` is now assigned partition `j`.
+*   **`ctrl->tpwgts`**: Target partition weights, used by `SimilarTpwgts`.
+*   **`NREMAP_PASSES`**: Constant from `defs.h`, number of passes for the greedy mapping heuristic.
+*   **`SMALLFLOAT`**: Constant from `defs.h`, used in `SimilarTpwgts` for floating point comparisons.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions. `ParallelReMapGraph` is typically called after a k-way partitioning (e.g., in `ParMETIS_V3_PartKway` or `ParMETIS_V3_AdaptiveRepart`) when `nparts == npes`, to optimize the assignment of the computed partitions to the physical processors.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants.
+    *   GKlib utilities: `iset`, `icopy`, `iargmax`, `ikvsorti`, `GlobalSESum`.
+    *   `graph.c` (specifically `graph->vsize`, `graph->where`).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for `gkMPI_Allgather`, `gkMPI_Scan` (implicitly if used by `GlobalSESum`).
+*   **Other Interactions**:
+    *   Modifies `graph->where` by applying the computed `map`.
+    *   The remapping is only effective if `nparts == npes`.
+    *   The `SimilarTpwgts` check prevents remapping partitions in a way that would violate target weight compatibility between the original partition slot and the target processor's slot, which is important for heterogeneous target weights.
+
+```

--- a/documentation/rename.h.md
+++ b/documentation/rename.h.md
@@ -1,0 +1,87 @@
+# libparmetis/rename.h
+
+## Overview
+
+This header file is part of ParMETIS's strategy to avoid symbol clashes with other libraries or user code, similar to `gklib_rename.h` but for ParMETIS's own internal functions. It defines macros that prepend `libparmetis__` to a comprehensive list of ParMETIS internal function names. When the ParMETIS library is compiled, these macros ensure that the compiled symbols have this prefix.
+
+This mechanism is primarily for internal use and allows ParMETIS to be robustly linked into larger applications that might, for example, use different versions of METIS/ParMETIS or have functions with coincidentally similar names.
+
+## Key Components
+
+### Functions/Classes/Modules/Macros/Structs
+
+This file consists entirely of `#define` preprocessor directives. Each directive renames an internal ParMETIS function.
+
+Examples of redefinitions:
+*   `#define KWayAdaptiveRefine libparmetis__KWayAdaptiveRefine`
+*   `#define CommSetup libparmetis__CommSetup`
+*   `#define Match_Global libparmetis__Match_Global`
+*   `#define InitPartition libparmetis__InitPartition`
+*   `#define KWayFM libparmetis__KWayFM`
+*   `#define MoveGraph libparmetis__MoveGraph`
+*   `#define Balance_Partition libparmetis__Balance_Partition`
+*   `#define Mc_Diffusion libparmetis__Mc_Diffusion`
+*   `#define MultilevelOrder libparmetis__MultilevelOrder`
+*   ... and many more, covering functions from most `.c` files in `libparmetis`.
+
+The list includes functions related to:
+*   Adaptive refinement (`KWayAdaptiveRefine`)
+*   Partitioning core logic (`Adaptive_Partition`, `Global_Partition`)
+*   Balancing (`BalanceMyLink`, `RedoMyLink`, `Balance_Partition`)
+*   Communication (`CommSetup`, `CommInterfaceData`)
+*   Matching and Coarsening (`CSR_Match_SHEM`, `Match_Global`, `CreateCoarseGraph_Global`)
+*   Control structure management (`SetupCtrl`, `FreeCtrl`)
+*   Debugging (`PrintGraph`, `PrintVector`)
+*   Diffusion utilities (`ComputeLoad`, `ConjGrad2`)
+*   MPI wrappers (`gkMPI_Allreduce`, etc. - though these are often GKlib renames themselves, this file might list them for completeness or if ParMETIS has another layer of wrappers).
+*   Graph structure management (`CreateGraph`, `SetupGraph`)
+*   Initial partitioning/multisection (`InitPartition`, `InitMultisection`)
+*   Refinement (`KWayFM`, `KWayBalance`, `ProjectPartition`)
+*   Remapping and Moving graphs (`ParallelReMapGraph`, `MoveGraph`)
+*   Mesh operations and setup (`SetUpMesh`) - *Self-correction: `SetUpMesh` is listed, but `ParMETIS_V3_Mesh2Dual` (the API function from `mesh.c`) is not, as API functions are not renamed.*
+*   Node refinement for ordering (`KWayNodeRefine_Greedy`)
+*   Ordering (`MultilevelOrder`, `CompactGraph`)
+*   Serial utilities used in parallel context (`ComputeSerialEdgeCut`)
+*   Statistics and timing (`ComputeParallelBalance`, `PrintTimingInfo`)
+*   General utilities (`BSearch`, `RandomPermute`)
+*   Workspace management (`AllocateWSpace`)
+*   Geometric partitioning (`Coordinate_Partition`)
+
+## Important Variables/Constants
+
+Not applicable, as this file only contains macro definitions for renaming functions.
+
+## Usage Examples
+
+```c
+// This header file is not directly used by end-users.
+// It's included by parmetislib.h, which is the main internal header.
+
+// In a ParMETIS internal .c file (e.g., kmetis.c):
+// #include <parmetislib.h> // This will include rename.h (likely before proto.h)
+// ...
+// // When kmetis.c calls Match_Global(...), the preprocessor
+// // changes it to libparmetis__Match_Global(...) before compilation.
+
+// In proto.h (function prototypes):
+// void libparmetis__Match_Global(ctrl_t *, graph_t *);
+//
+// In match.c (function implementation):
+// void libparmetis__Match_Global(ctrl_t *ctrl, graph_t *graph) {
+//   // ...
+// }
+```
+When ParMETIS source code is compiled, any call to an internal ParMETIS function listed in `rename.h` is replaced by its `libparmetis__` prefixed version. The actual implementations of these functions also use these prefixed names.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   This file is included by `parmetislib.h`.
+    *   It directly affects how internal function calls are compiled. The function implementations in their respective `.c` files must define the `libparmetis__*` prefixed names. The function prototypes in `proto.h` must also declare these prefixed names.
+    *   It's a companion to `gklib_rename.h`, which does the same for embedded GKlib functions. This `rename.h` handles ParMETIS's own internal functions.
+*   **External Libraries**:
+    *   None. This file only contains preprocessor definitions.
+*   **Other Interactions**:
+    *   This renaming strategy is crucial for creating a robust ParMETIS library that avoids symbol name conflicts when linked into larger applications or with other libraries. It encapsulates ParMETIS's internal symbols.
+
+```

--- a/documentation/renumber.c.md
+++ b/documentation/renumber.c.md
@@ -1,0 +1,87 @@
+# libparmetis/renumber.c
+
+## Overview
+
+This file provides utility functions to switch graph and mesh numbering schemes between 0-based and 1-based indexing. ParMETIS internally uses 0-based indexing, but some users or external tools might provide or expect 1-based indexing. These functions handle the necessary conversions for various graph and mesh data arrays.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ChangeNumbering(idx_t *vtxdist, idx_t *xadj, idx_t *adjncy, idx_t *part, idx_t npes, idx_t mype, idx_t from)`**:
+    *   Converts graph numbering for standard CSR graph representation.
+    *   **Parameters**:
+        *   `vtxdist`: Vertex distribution array.
+        *   `xadj`, `adjncy`: CSR graph structure arrays.
+        *   `part`: Partition assignment array for vertices.
+        *   `npes`: Number of processors.
+        *   `mype`: Current processor's rank.
+        *   `from`: If 1, converts from 1-based to 0-based. If 0, converts from 0-based to 1-based.
+    *   **Functionality**:
+        *   If `from == 1` (1-based to 0-based):
+            *   Decrements elements of `vtxdist`.
+            *   Decrements elements of `xadj`.
+            *   Decrements elements of `adjncy`.
+            *   The `part` array is NOT modified by this function (though it's a parameter, it's typically handled separately or assumed to be 0-based if `numflag` applies to it in API calls).
+        *   If `from == 0` (0-based to 1-based):
+            *   Increments elements of `vtxdist`.
+            *   Increments elements of `adjncy`.
+            *   Increments elements of `xadj`.
+            *   Increments elements of `part`.
+*   **`ChangeNumberingMesh(idx_t *elmdist, idx_t *eptr, idx_t *eind, idx_t *xadj, idx_t *adjncy, idx_t *part, idx_t npes, idx_t mype, idx_t from)`**:
+    *   Converts numbering for a mesh and its optional dual graph.
+    *   **Parameters**:
+        *   `elmdist`: Element distribution array.
+        *   `eptr`, `eind`: Mesh element connectivity arrays (elements to nodes).
+        *   `xadj`, `adjncy`: CSR structure of the dual graph (if computed and passed).
+        *   `part`: Partition assignment array for elements (or dual graph vertices).
+        *   `npes`: Number of processors.
+        *   `mype`: Current processor's rank.
+        *   `from`: If 1, converts from 1-based to 0-based. If 0, converts from 0-based to 1-based.
+    *   **Functionality**:
+        *   If `from == 1` (1-based to 0-based):
+            *   Decrements `elmdist`.
+            *   Decrements `eptr`.
+            *   Decrements `eind` (node indices in the mesh).
+        *   If `from == 0` (0-based to 1-based):
+            *   Increments `elmdist`.
+            *   Increments `eind`.
+            *   Increments `eptr`.
+            *   If `xadj` and `adjncy` (dual graph) are provided:
+                *   Increments `adjncy` of the dual graph.
+                *   Increments `xadj` of the dual graph.
+            *   If `part` (element partition) is provided:
+                *   Increments `part`.
+
+## Important Variables/Constants
+
+*   **`from` (parameter)**: Determines the direction of conversion (1 for 1-to-0, 0 for 0-to-1).
+
+## Usage Examples
+
+```c
+// Conceptual usage within an API function:
+// if (*numflag > 0) { // User specified 1-based numbering
+//   ChangeNumbering(vtxdist, xadj, adjncy, part, npes, mype, 1); // Convert to 0-based
+// }
+//
+// /* ... ParMETIS internal logic using 0-based numbering ... */
+//
+// if (*numflag > 0) { // If original was 1-based
+//   ChangeNumbering(vtxdist, xadj, adjncy, part, npes, mype, 0); // Convert back to 1-based
+// }
+```
+These functions are typically called at the beginning and end of ParMETIS API functions if the user specifies `numflag = 1`.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `idx_t` type definition.
+    *   These functions directly modify the input arrays (`vtxdist`, `xadj`, `adjncy`, `part`, `elmdist`, `eptr`, `eind`).
+*   **External Libraries**:
+    *   None.
+*   **Other Interactions**:
+    *   Crucial for user convenience, allowing users to work with 1-based indexing if that's their native format, while ParMETIS internals operate with 0-based indexing.
+    *   Incorrectly managing the `from` flag or calling these functions inappropriately can lead to severe errors due to incorrect graph/mesh representation.
+
+```

--- a/documentation/rmetis.c.md
+++ b/documentation/rmetis.c.md
@@ -1,0 +1,90 @@
+# libparmetis/rmetis.c
+
+## Overview
+
+This file is the entry point for the ParMETIS V3 API function `ParMETIS_V3_RefineKway`. This function is designed to refine an existing k-way partition of a distributed graph. It uses a parallel multilevel approach that involves coarsening the graph, refining the partition at the coarsest level (often by leveraging adaptive partitioning techniques), and then projecting the refinement back through the levels to the original graph.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ParMETIS_V3_RefineKway(idx_t *vtxdist, idx_t *xadj, idx_t *adjncy, idx_t *vwgt, idx_t *adjwgt, idx_t *wgtflag, idx_t *numflag, idx_t *ncon, idx_t *nparts, real_t *tpwgts, real_t *ubvec, idx_t *options, idx_t *edgecut, idx_t *part, MPI_Comm *comm)`**:
+    *   This is the V3 API function for k-way partition refinement.
+    *   **Parameters**:
+        *   `vtxdist`, `xadj`, `adjncy`: Distributed graph structure.
+        *   `vwgt`, `adjwgt`: Vertex and edge weights.
+        *   `wgtflag`: Flags for presence of weights.
+        *   `numflag`: 0-based or 1-based indexing.
+        *   `ncon`: Number of constraints.
+        *   `nparts`: Number of partitions (must match the existing partition in `part`).
+        *   `tpwgts`: Target partition weights.
+        *   `ubvec`: Load imbalance tolerance.
+        *   `options`: ParMETIS options array.
+        *   `edgecut` (output): Stores the edge cut of the refined partition.
+        *   `part` (input/output): Input is the existing partition; output is the refined partition.
+        *   `comm`: MPI communicator.
+    *   **Functionality**:
+        1.  Performs input validation using `CheckInputsPartKway` (the same check as for k-way partitioning from scratch, as many parameters are similar).
+        2.  Initializes memory management and sets up the `ctrl_t` control structure with `optype = PARMETIS_OP_RMETIS`.
+        3.  Handles the trivial case of `nparts == 1`.
+        4.  If `numflag > 0`, converts graph numbering to 0-based (`ChangeNumbering`).
+        5.  Sets up the `graph_t` structure (`SetupGraph`).
+        6.  Initializes `graph->home`:
+            *   If `ctrl->ps_relation == PARMETIS_PSR_COUPLED`, `home` is set to the current PE ID for all local vertices.
+            *   Otherwise (uncoupled), `home` is initialized with the input `part` array. This `home` array represents the initial partition that will be refined.
+        7.  Allocates workspace (`AllocateWSpace`).
+        8.  Sets `ctrl->CoarsenTo`, a threshold for stopping coarsening (typically larger for refinement than for partitioning from scratch, to allow more levels for refinement to work on).
+        9.  Calls `Adaptive_Partition(ctrl, graph)`. Despite its name, when `ctrl->partType` is `REFINE_PARTITION` (as set by `PARMETIS_OP_RMETIS`), `Adaptive_Partition` executes refinement-focused logic. This usually involves coarsening the graph while respecting the `home` assignments, potentially performing some balancing or refinement at the coarsest level, and then uncoarsening with refinement steps like `KWayAdaptiveRefine`.
+        10. Remaps the graph based on the refined partition (`ParallelReMapGraph`).
+        11. Copies the refined partition from `graph->where` to the output `part` array.
+        12. Stores the computed edge cut in `*edgecut`.
+        13. Prints timing and statistics if debug flags are set.
+        14. Frees graph structures and control structures.
+        15. If `numflag > 0`, converts numbering back to 1-based.
+        16. Checks for memory leaks.
+
+## Important Variables/Constants
+
+*   **`ctrl->partType`**: Set to `REFINE_PARTITION` via `PARMETIS_OP_RMETIS`.
+*   **`ctrl->ps_relation`**: `PARMETIS_PSR_COUPLED` or `PARMETIS_PSR_UNCOUPLED`, influences how `graph->home` is set and potentially affects coarsening/refinement strategies.
+*   **`graph->home`**: Stores the initial partition to be refined.
+*   **`graph->where`**: Stores the refined partition after the process.
+*   All other parameters are standard for ParMETIS partitioning/refinement calls.
+
+## Usage Examples
+
+```c
+// Conceptual call to ParMETIS_V3_RefineKway
+// (assuming vtxdist, xadj, adjncy, part (existing partition), comm, etc. are set up)
+// idx_t options[PARMETIS_MAX_OPTIONS]; options[0] = 0; // Default options
+// idx_t edgecut_val;
+//
+// // part contains the initial k-way partition to be refined
+// ParMETIS_V3_RefineKway(vtxdist, xadj, adjncy, vwgt, adjwgt,
+//                        &wgtflag, &numflag, &ncon, &nparts_val,
+//                        tpwgts, ubvec, options,
+//                        &edgecut_val, part, &comm);
+//
+// // 'part' is now updated with the refined partition.
+// // 'edgecut_val' is the new edge cut.
+```
+This is an API function.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions.
+    *   `ctrl.c`: For `SetupCtrl`, `FreeCtrl`.
+    *   `graph.c`: For `SetupGraph`, `FreeInitialGraphAndRemap`.
+    *   `wspace.c`: For `AllocateWSpace`.
+    *   `comm.c`: For `CheckInputsPartKway`, `GlobalSEMinComm`.
+    *   `ametis.c`: `Adaptive_Partition` is the core multilevel routine called.
+    *   `remap.c`: For `ParallelReMapGraph`.
+    *   `util.c`: For `ChangeNumbering`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: For all parallel communication.
+*   **Other Interactions**:
+    *   This function takes an existing partition as input (`part` array, copied to `graph->home`) and aims to improve its quality (reduce edge cut) while maintaining balance.
+    *   The behavior of the underlying `Adaptive_Partition` function changes based on `ctrl->partType` being `REFINE_PARTITION`.
+
+```

--- a/documentation/selectq.c.md
+++ b/documentation/selectq.c.md
@@ -1,0 +1,68 @@
+# libparmetis/selectq.c
+
+## Overview
+
+This file provides utility functions for selecting which priority queue to draw a vertex from during certain multi-constraint refinement or balancing operations, specifically within diffusion-based algorithms (`mdiffusion.c`). It also includes helper functions to compute hash values based on vertex weights, which are used to distribute vertices among multiple priority queues. The queue selection logic aims to prioritize moves that best alleviate imbalance across multiple constraints.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`Mc_DynamicSelectQueue(ctrl_t *ctrl, idx_t nqueues, idx_t ncon, idx_t subdomain1, idx_t subdomain2, idx_t *currentq, real_t *flows, idx_t *from, idx_t *qnum, idx_t minval, real_t avgvwgt, real_t maxdiff)`**:
+    *   Dynamically selects a queue (`*qnum`) and a source partition (`*from`) from which to pick a vertex for a potential move. This is used in multi-constraint scenarios where vertices are categorized into `nqueues` (based on weight hashes) and there are `ncon` constraints.
+    *   **Parameters**:
+        *   `nqueues`: Number of queues per partition side.
+        *   `ncon`: Number of constraints.
+        *   `subdomain1`, `subdomain2`: The two subdomains/partitions involved in the potential move.
+        *   `currentq`: An array indicating the number of elements currently in each actual priority queue.
+        *   `flows`: An array of size `ncon` indicating the current imbalance for each constraint between `subdomain1` and `subdomain2`.
+        *   `from` (output): The selected source subdomain (either `subdomain1` or `subdomain2`). If initially -1, it's determined by the largest flow.
+        *   `qnum` (output): The index of the selected queue (0 to `nqueues-1`).
+        *   `minval`: Minimum hash value, used to adjust `qnum`.
+        *   `avgvwgt`: Average vertex weight, used as a threshold with `MOC_GD_GRANULARITY_FACTOR`.
+        *   `maxdiff`: Maximum difference between sorted flow components to consider them "close".
+    *   **Functionality**:
+        1.  If `*from` is -1, determines the initial `*from` partition based on the constraint with the largest absolute `flows` value. If `flows[c] > avgvwgt_thresh`, `*from = subdomain1`; if `flows[c] < -avgvwgt_thresh`, `*from = subdomain2`.
+        2.  Sorts the `flows` (multiplied by a `sign` depending on `*from`) to determine the order of importance of constraints.
+        3.  Identifies "don't care" constraints: if flow values for adjacent constraints in the sorted list are close (difference `< maxdiff * MC_FLOW_BALANCE_THRESHOLD`), they are grouped.
+        4.  Based on `ncon` (hardcoded for 2, 3, 4 constraints) and the "don't care" grouping, it generates a list of candidate permutations (`perm`) of constraint indices. These permutations represent different orderings of preference for satisfying constraints.
+        5.  Iterates through these permutations. For each permutation, it forms a hash value representing a vertex type that would be ideal to move (using `Mc_HashVRank`).
+        6.  If a queue corresponding to this hash value (`hash - minval + index`) has elements (`currentq[q_idx] > 0`), that queue `*qnum` is selected, and the function returns.
+*   **`Mc_HashVwgts(ctrl_t *ctrl, idx_t ncon, real_t *nvwgt)`**:
+    *   Computes a hash value for a vertex based on its normalized weights (`nvwgt`) across `ncon` constraints.
+    *   It first sorts the constraints by the vertex's weight in them.
+    *   Then, it calculates a unique integer based on the ranks of these sorted weights. This hash value is used to assign vertices to one of `nqueues` in refinement algorithms like `BalanceMyLink`.
+*   **`Mc_HashVRank(idx_t ncon, idx_t *vwgt)`**:
+    *   Computes a hash value based on an already determined ranking of constraints for a vertex.
+    *   `vwgt` here is expected to be an array of ranks (0 to `ncon-1`).
+    *   Calculates `retval = sum(vwgt[ncon-1-i] * (i+1)!)`. This provides a unique integer for each permutation of ranks.
+
+## Important Variables/Constants
+
+*   **`flows`**: Array of imbalances for each constraint. Drives the selection of which constraint to prioritize.
+*   **`perm` (in `Mc_DynamicSelectQueue`)**: A 2D array holding pre-defined permutations of constraint indices for `ncon` = 2, 3, 4. These permutations guide the search for a suitable queue.
+*   **`MOC_GD_GRANULARITY_FACTOR`**: Multiplier for `avgvwgt` to set a threshold for flow significance.
+*   **`MC_FLOW_BALANCE_THRESHOLD`**: Factor for `maxdiff` to determine if flows are "close enough" to be grouped as "don't cares".
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal helper functions for ParMETIS, specifically for multi-constraint refinement and balancing algorithms.
+*   `Mc_DynamicSelectQueue` would be called within a loop in a routine like `BalanceMyLink` (in `balancemylink.c`) or the diffusion code to decide which type of vertex (from which queue) to consider moving next.
+*   `Mc_HashVwgts` is used to assign vertices to specific queues based on their weight distributions when initializing those queues.
+*   `Mc_HashVRank` is used by `Mc_DynamicSelectQueue` to generate target hash values based on prioritized constraint rankings.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `idx_t`, `real_t`, `rkv_t` types, MPI wrappers (`gkMPI_Comm_rank`), memory utilities (`iwspacemalloc`, `rkvwspacemalloc`, `WCOREPUSH`/`POP`), sorting (`rkvsorti`).
+    *   `mdiffusion.c` and `balancemylink.c` (or similar refinement/balancing routines) are the primary callers of these functions.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: `gkMPI_Comm_rank` is called, but its result `mype` is not used in the logic of these specific functions.
+*   **Other Interactions**:
+    *   The hardcoded permutations in `Mc_DynamicSelectQueue` for `ncon` up to 4 limit its direct applicability for a higher number of constraints without extension.
+    *   The hashing functions are designed to group vertices with similar weight distributions or rankings, allowing refinement heuristics to target specific vertex types.
+
+```

--- a/documentation/serial.c.md
+++ b/documentation/serial.c.md
@@ -1,0 +1,87 @@
+# libparmetis/serial.c
+
+## Overview
+
+This file contains serial (non-parallel) graph partitioning and refinement routines that are used as components within the larger parallel ParMETIS algorithms. These functions typically operate on graph data that has been assembled onto a single processor or is being processed in a serial fashion as part of a more complex parallel scheme (e.g., refining a local subgraph or a graph representing connectivity between partitions). The file includes utilities for computing partition parameters, performing 2-way and k-way refinement, and balancing for serial graphs.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`Mc_ComputeSerialPartitionParams(ctrl_t *ctrl, graph_t *graph, idx_t nparts)`**:
+    *   Computes partition parameters (internal/external degrees, partition weights) for a serial graph `graph` that is partitioned into `nparts`.
+    *   Similar to `ComputePartitionParams` but for a non-distributed graph context.
+*   **`Mc_SerialKWayAdaptRefine(ctrl_t *ctrl, graph_t *graph, idx_t nparts, idx_t *home, real_t *orgubvec, idx_t npasses)`**:
+    *   Performs k-way adaptive refinement on a serial graph.
+    *   Uses a greedy approach, sorting vertices by gain (`ed-id`).
+    *   Iteratively moves vertices to other partitions if the move improves cut or balance, respecting weight constraints (`maxwgt`, `minwgt` derived from `orgubvec`).
+    *   Updates degrees and partition weights after each move.
+*   **`AreAllHVwgtsBelow(idx_t ncon, real_t alpha, real_t *vwgt1, real_t beta, real_t *vwgt2, real_t *limit)`**:
+    *   Utility to check if a linear combination of vertex weights (`alpha*vwgt1 + beta*vwgt2`) is below a `limit` for all constraints. Used for balance checks.
+*   **`ComputeHKWayLoadImbalance(idx_t ncon, idx_t nparts, real_t *npwgts, real_t *lbvec)`**:
+    *   Computes the load imbalance for a k-way partition. `lbvec[i]` stores `max_weight_for_constraint_i * nparts`.
+*   **`SerialRemap(ctrl_t *ctrl, graph_t *graph, idx_t nparts, idx_t *base, idx_t *scratch, idx_t *remap, real_t *tpwgts)`**:
+    *   Remaps a serial k-way partition to minimize redistribution cost, similar to `ParallelTotalVReMap` but for a serial context.
+    *   `base` is the initial partition, `scratch` is the target partition (e.g., from a different strategy), `remap` is the output mapping.
+    *   Uses a heuristic based on matching heaviest flows between `base` and `scratch` partitions.
+*   **`SSMIncKeyCmp(const void *fptr, const void *sptr)`**:
+    *   Comparison function for `qsort`, used by `SerialRemap` to sort `i2kv_t` structures (key1 ascending, then key2 descending).
+*   **`Mc_Serial_FM_2WayRefine(ctrl_t *ctrl, graph_t *graph, real_t *tpwgts, idx_t npasses)`**:
+    *   Performs 2-way FM refinement on a serial graph.
+    *   Uses priority queues (`rpq_t`) to select vertices for moves.
+    *   Iteratively moves vertices to reduce cut or improve balance (defined by `tpwgts` and `origbal`).
+    *   Includes a rollback mechanism to the best state found if moves exceed a `limit` without improvement.
+*   **`Serial_SelectQueue(idx_t ncon, real_t *npwgts, real_t *tpwgts, idx_t *from, idx_t *cnum, rpq_t **queues[2])`**:
+    *   Selects a queue for 2-way FM based on which partition is most overweight or offers the best gain.
+*   **`Serial_BetterBalance(idx_t ncon, real_t *npwgts, real_t *tpwgts, real_t *diff, real_t *tmpdiff)`**:
+    *   Checks if the current partition `npwgts` is better balanced towards `tpwgts` than a previous state represented by `diff` (sum of absolute differences).
+*   **`Serial_Compute2WayHLoadImbalance(idx_t ncon, real_t *npwgts, real_t *tpwgts)`**:
+    *   Computes load imbalance for a 2-way partition (max relative deviation).
+*   **`Mc_Serial_Balance2Way(ctrl_t *ctrl, graph_t *graph, real_t *tpwgts, real_t lbfactor)`**:
+    *   Balances a 2-way partition to meet `lbfactor` (load balance factor) by moving high-gain vertices.
+    *   Uses priority queues and similar logic to FM refinement but prioritizes balance.
+*   **`Mc_Serial_Init2WayBalance(ctrl_t *ctrl, graph_t *graph, real_t *tpwgts)`**:
+    *   Initializes balance for a 2-way partition, typically moving vertices from an overweight partition (`from=1`) to an underweight one (`to=0`) until weights are closer to `tpwgts`.
+*   **`Serial_SelectQueueOneWay(idx_t ncon, real_t *npwgts, real_t *tpwgts, idx_t from, rpq_t **queues[2])`**:
+    *   Selects a queue for one-way balancing, picking the constraint that is most overweight in the `from` partition.
+*   **`Mc_Serial_Compute2WayPartitionParams(ctrl_t *ctrl, graph_t *graph)`**:
+    *   Computes parameters (id/ed degrees, boundary) for a 2-way serial graph partition.
+*   **`Serial_AreAnyVwgtsBelow(idx_t ncon, real_t alpha, real_t *vwgt1, real_t beta, real_t *vwgt2, real_t *limit)`**:
+    *   Utility to check if `alpha*vwgt1 + beta*vwgt2` is below `limit` for any constraint.
+*   **`ComputeSerialEdgeCut(graph_t *graph)`**: Calculates the edge cut of a serial graph.
+*   **`ComputeSerialTotalV(graph_t *graph, idx_t *home)`**: Calculates total weight of vertices not in their home partition for a serial graph.
+
+## Important Variables/Constants
+
+*   `graph_t`: Represents the serial graph being processed.
+*   `ctrl_t`: Control structure (though less MPI-dependent here, still used for workspace and parameters).
+*   `where`: Partition assignment array for vertices.
+*   `id`, `ed`: Internal and external degrees.
+*   `bndptr`, `bndind`: Boundary vertex data structures.
+*   `npwgts`: Normalized partition weights.
+*   `tpwgts`: Target partition weights.
+*   `rpq_t`: Priority queue type from GKlib.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions. They are called by other parallel routines when a serial computation is needed on a subgraph or an assembled graph. For example:
+*   `Mc_SerialKWayAdaptRefine` might be used by `Mc_Diffusion`.
+*   `Mc_Serial_FM_2WayRefine` and related functions are used by `RedoMyLink`.
+*   `SerialRemap` is used by `Balance_Partition`.
+*   `ComputeSerialEdgeCut` and `ComputeSerialBalance` (in `stat.c`, but a version might be used here or called) are used for reporting or decision-making.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants, GKlib utilities (memory, sorting, PQs, array ops).
+    *   `macros.h`: For `BNDInsert`, `BNDDelete`, `INC_DEC`, `gk_SWAP`, `WCOREPUSH`/`POP`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: `gkMPI_Comm_rank` is called in a few places, but the result is often unused or for debugging, as these routines primarily assume serial operation on the provided `graph_t` data.
+*   **Other Interactions**:
+    *   These functions form the building blocks for local refinement or processing steps within larger parallel strategies.
+    *   They often replicate logic found in serial METIS but are adapted for ParMETIS's data structures and multi-constraint capabilities.
+
+```

--- a/documentation/stat.c.md
+++ b/documentation/stat.c.md
@@ -1,0 +1,69 @@
+# libparmetis/stat.c
+
+## Overview
+
+This file contains utility functions for computing and printing various statistics related to graph partitions in ParMETIS. These include calculating load balance (for both serial and parallel contexts), printing partition quality information (edge cut, balance), and computing statistics about vertex movements during adaptive refinement or repartitioning.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`ComputeSerialBalance(ctrl_t *ctrl, graph_t *graph, idx_t *where, real_t *ubvec)`**:
+    *   Computes the load balance for a k-way partition of a serial graph.
+    *   `where`: Array indicating partition assignment for each vertex.
+    *   `ubvec` (output): Array where `ubvec[j]` will store the imbalance for the j-th constraint. Imbalance is calculated as `max_part_weight_j / ideal_part_weight_j`.
+    *   `ideal_part_weight_j` is `total_weight_j / nparts`.
+*   **`ComputeParallelBalance(ctrl_t *ctrl, graph_t *graph, idx_t *where, real_t *ubvec)`**:
+    *   Computes the load balance for a k-way partition of a distributed graph.
+    *   `where`: Local partition assignments.
+    *   `ubvec` (output): Imbalance for each constraint.
+    *   It first computes local partition weights (`lnpwgts`) using normalized vertex weights (`graph->nvwgt`).
+    *   Then, it performs an `MPI_Allreduce` to get global partition weights (`gnpwgts`).
+    *   Imbalance for constraint `j` is `max_over_i(gnpwgts[i*ncon+j] / tpwgts[i*ncon+j])`, adjusted by a minimum vertex weight to handle zero target weights.
+*   **`Mc_PrintThrottleMatrix(ctrl_t *ctrl, graph_t *graph, real_t *matrix)`**:
+    *   Prints a matrix (presumably `npes x npes`) representing some form of "throttle" or interaction between processors. Output is synchronized by PE.
+*   **`PrintPostPartInfo(ctrl_t *ctrl, graph_t *graph, idx_t movestats)`**:
+    *   Prints summary information after a partitioning or refinement process.
+    *   Displays final edge cut (`graph->mincut`).
+    *   Calculates and prints the balance for each constraint using global partition weights (`graph->gnpwgts`) and target weights (`ctrl->tpwgts`).
+    *   If `movestats` is true, calls `Mc_ComputeMoveStatistics` and prints vertex movement data.
+*   **`ComputeMoveStatistics(ctrl_t *ctrl, graph_t *graph, idx_t *nmoved, idx_t *maxin, idx_t *maxout)`**:
+    *   (Slightly different version than `Mc_ComputeMoveStatistics` in `diffutil.c` or `mdiffusion.c`; this one seems simpler and counts vertices rather than vertex weights/sizes for movement).
+    *   Calculates:
+        *   `nmoved`: Total number of local vertices not in their assigned partition `ctrl->mype`.
+        *   `maxout`: Maximum number of vertices moved out from any single PE (which is the local `j`).
+        *   `maxin`: Maximum number of vertices moved into any single PE.
+    *   Uses `MPI_Allreduce` and `GlobalSEMax/GlobalSESum`.
+
+## Important Variables/Constants
+
+*   **`graph->vwgt`**: Vertex weights (used in `ComputeSerialBalance`).
+*   **`graph->nvwgt`**: Normalized vertex weights (used in `ComputeParallelBalance`).
+*   **`graph->where` / `where`**: Partition assignment array.
+*   **`ctrl->tpwgts`**: Target partition weights.
+*   **`graph->gnpwgts`**: Global actual partition weights.
+*   **`graph->mincut`**: Computed global edge cut.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal utility functions.
+*   `ComputeSerialBalance` and `ComputeParallelBalance` are called by various algorithms to assess the balance of current or proposed partitions.
+*   `PrintPostPartInfo` is called at the end of major operations (like `ParMETIS_V3_PartKway`, `ParMETIS_V3_RefineKway`) if debugging flags for informational output are enabled.
+*   `ComputeMoveStatistics` provides metrics for how much data redistribution occurred.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions (`ctrl_t`, `graph_t`), types, MPI wrappers, memory utilities.
+    *   `diffutil.c` or `mdiffusion.c`: For `Mc_ComputeMoveStatistics` (though there's a local simpler version `ComputeMoveStatistics` here too).
+    *   GKlib utilities: `ismalloc`, `rset`, `rwspacemalloc`, `gk_max`, `gk_free`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used in `ComputeParallelBalance`, `Mc_PrintThrottleMatrix`, and `ComputeMoveStatistics` for collective operations.
+*   **Other Interactions**:
+    *   These functions provide crucial feedback on algorithm performance (balance, cut) and data movement, often used for debugging or reporting final quality.
+    *   The balance calculation methods differ slightly between serial and parallel versions, mainly in how total weights and target weights are handled (raw weights vs. normalized weights).
+
+```

--- a/documentation/struct.h.md
+++ b/documentation/struct.h.md
@@ -1,0 +1,121 @@
+# libparmetis/struct.h
+
+## Overview
+
+This header file defines the core internal data structures used throughout the ParMETIS library. These structures are essential for representing graphs, meshes, control parameters, refinement information, and other auxiliary data needed by the various parallel graph partitioning and ordering algorithms.
+
+## Key Components
+
+### Functions/Classes/Modules/Macros/Structs
+
+This file primarily consists of `typedef struct` definitions.
+
+*   **`cnbr_t`**:
+    *   Stores information about a neighboring partition for a given vertex during cut-based k-way refinement.
+    *   `pid`: The partition ID of the neighbor.
+    *   `ed`: The sum of weights of edges connecting the vertex to this neighboring partition.
+*   **`i2kv_t`**:
+    *   A simple structure to store a triplet of `idx_t` values: `key1`, `key2`, and `val`. Used for sorting or storing multi-keyed data.
+*   **`ckrinfo_t`**:
+    *   Stores cut-based k-way refinement information for a vertex.
+    *   `id`: Internal degree (sum of weights of edges to vertices in the same partition).
+    *   `ed`: External degree (sum of weights of edges to vertices in different partitions).
+    *   `nnbrs`: Number of distinct neighboring partitions.
+    *   `inbr`: Index into a global pool (`ctrl->cnbrpool`) where the list of `cnbr_t` for this vertex is stored.
+*   **`NRInfoType` (and `nrinfodef`)**:
+    *   Stores node-refinement information, specifically for 2-way (bisection/multisection) scenarios.
+    *   `edegrees[2]`: Stores the sum of vertex weights of neighbors in partition 0 and partition 1, respectively, for a separator node.
+*   **`matrix_t`**:
+    *   Represents a sparse matrix, often used for connectivity graphs between partitions in diffusion algorithms.
+    *   `nrows`, `nnzs`: Number of rows and non-zeros.
+    *   `rowptr`, `colind`: CSR row pointers and column indices.
+    *   `values`: Matrix values (often diagonal elements store degree/self-loop, off-diagonals are negative).
+    *   `transfer`: Array to store flow/transfer values associated with matrix edges (non-zeros).
+*   **`graph_t`**:
+    *   The main structure for representing a distributed graph. It's a complex structure containing:
+        *   Basic graph info: `gnvtxs` (global vertices), `nvtxs` (local vertices), `nedges`, `ncon` (number of constraints).
+        *   CSR data: `xadj`, `adjncy`, `adjwgt`.
+        *   Vertex data: `vwgt` (weights), `nvwgt` (normalized weights), `vsize` (sizes for redistribution).
+        *   Distribution: `vtxdist`.
+        *   Partitioning info: `home` (initial partition), `where` (current partition).
+        *   Memory ownership flags: `free_xadj`, `free_adjncy`, etc.
+        *   Coarsening info: `match`, `cmap`.
+        *   Communication setup: `nnbrs`, `nrecv`, `nsend`, `peind`, `sendptr`/`ind`, `recvptr`/`ind`, `imap`, `pexadj`/`peadjncy`/`peadjloc`, `lperm`.
+        *   Projection info: `rlens`, `slens`, `rcand`.
+        *   Refinement info: `lpwgts`/`gpwgts` (partition weights, older style), `lnpwgts`/`gnpwgts` (normalized partition weights), `ckrinfo` (for k-way edge refinement), `nrinfo` (for node refinement), `sepind`.
+        *   Cut info: `lmincut`, `mincut`.
+        *   Multilevel hierarchy: `level`, `coarser`, `finer` pointers.
+        *   On-disk processing: `gID`, `ondisk`.
+*   **`timer` (typedef double)**: Defines the type used for timing various operations.
+*   **`ctrl_t`**:
+    *   The main control structure, holding global parameters and state for a ParMETIS operation.
+    *   Operation type: `optype`.
+    *   MPI info: `mype`, `npes`, `gcomm`, `comm`, request arrays.
+    *   Partitioning parameters: `ncon`, `nparts`, `CoarsenTo`, `tpwgts`, `ubvec`, `ubfrac`.
+    *   Algorithm choices: `mtype` (matching), `ipart` (initial partitioning), `rtype` (refinement).
+    *   Debugging: `dbglvl`, `seed`.
+    *   Factors: `redist_factor`, `ipc_factor`.
+    *   Workspace: `mcore` (GKlib memory core), `cnbrpool` and related fields for refinement neighbor lists.
+    *   On-disk info: `ondisk`, `pid`.
+    *   Timers: Numerous `timer` fields for profiling different stages.
+*   **`mesh_t`**:
+    *   Represents a distributed mesh.
+    *   `etype`: Element type.
+    *   `gnelms`, `nelms`: Global/local number of elements.
+    *   `gnns`: Global number of nodes.
+    *   `ncon`: Number of weights per element.
+    *   `esize`: Number of nodes per element.
+    *   `gminnode`: Global minimum node ID (for normalization).
+    *   `elmdist`: Distribution of elements.
+    *   `elements`: Element connectivity array.
+    *   `elmwgt`: Element weights.
+
+## Important Variables/Constants
+
+This file defines the *structure* of these variables. The actual instances and their values are managed by other parts of the library. Key concepts embodied by members:
+*   CSR representation for graphs and sparse matrices.
+*   Distinction between local and global vertex/element counts and indices.
+*   Storage for various weights and costs (vertex weights, edge weights, vertex sizes, partition weights).
+*   Pointers for building multilevel hierarchies (`coarser`, `finer`).
+*   Flags for memory management (`free_*`).
+*   Comprehensive communication buffers and metadata within `graph_t`.
+*   Detailed control parameters within `ctrl_t`.
+
+## Usage Examples
+
+```c
+// This is a header file. It's included by parmetislib.h, which is then
+// included by most .c files in the ParMETIS library.
+
+// Example: In graph.c
+// #include <parmetislib.h> // This will include struct.h
+//
+// graph_t *mygraph = CreateGraph(); // CreateGraph uses sizeof(graph_t)
+// mygraph->nvtxs = 100;
+// mygraph->xadj = imalloc(101, "xadj_for_mygraph");
+// // etc.
+
+// In kmetis.c
+// #include <parmetislib.h>
+//
+// void SomeFunction(ctrl_t *ctrl, graph_t *graph) {
+//   if (ctrl->dbglvl & DBG_INFO) { ... }
+//   idx_t nnbrs = graph->nnbrs;
+//   // ...
+// }
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Includes this file.
+    *   `parmetis.h` (via `parmetislib.h`): Provides `idx_t`, `real_t`, `pmoptype_et`, `MPI_Comm`, `MPI_Request`, `MPI_Status`.
+    *   `GKlib.h` (via `parmetislib.h`): Provides `ikv_t` (though ParMETIS also defines its own `ikv_t` via `gklib_defs.h` which might be slightly different or just namespaced), `gk_mcore_t`.
+    *   Nearly all `.c` files in `libparmetis` depend on these structure definitions to operate on graph data and control parameters.
+*   **External Libraries**:
+    *   `MPI`: MPI types are used in `ctrl_t`.
+*   **Other Interactions**:
+    *   These data structures are fundamental to the entire ParMETIS library. Changes to them would have widespread impact.
+    *   The design of `graph_t` and `ctrl_t` reflects the complexity of parallel multilevel graph algorithms, encompassing data for the graph itself, its distribution, partitioning state, refinement aids, communication buffers, and control knobs for algorithm behavior.
+
+```

--- a/documentation/timer.c.md
+++ b/documentation/timer.c.md
@@ -1,0 +1,75 @@
+# libparmetis/timer.c
+
+## Overview
+
+This file provides utility functions for managing and printing timing information within ParMETIS. It allows different parts of the code to be profiled by starting, stopping, and clearing timers. A summary of these timings can then be printed, showing the maximum and sum of times across all MPI processes for each profiled section, along with a balance metric.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`InitTimers(ctrl_t *ctrl)`**:
+    *   Initializes all predefined timers in the `ctrl_t` structure to zero.
+    *   Calls `cleartimer()` for each timer field in `ctrl_t` (e.g., `ctrl->TotalTmr`, `ctrl->MatchTmr`, etc.).
+*   **`PrintTimingInfo(ctrl_t *ctrl)`**:
+    *   Prints a summary of all the timers defined in `ctrl_t`.
+    *   For each timer, it calls `PrintTimer` to display its statistics.
+*   **`PrintTimer(ctrl_t *ctrl, timer tmr, char *msg)`**:
+    *   Calculates and prints statistics for a single timer value `tmr`.
+    *   The `msg` string is a descriptive label for the timer.
+    *   It performs MPI reductions to get the sum (`MPI_SUM`) and maximum (`MPI_MAX`) of the timer value `tmr` across all processors in `ctrl->comm`.
+    *   If the sum of the timer is non-zero, it prints the maximum time, sum of times, and a balance metric (`max_time * npes / sum_time`) on PE 0.
+
+## Important Variables/Constants
+
+*   **`ctrl_t` (struct)**: This structure holds all the timer variables. Examples:
+    *   `ctrl->TotalTmr`: Total time for the operation.
+    *   `ctrl->InitPartTmr`: Time for initial partitioning.
+    *   `ctrl->MatchTmr`: Time for matching.
+    *   `ctrl->ContractTmr`: Time for graph contraction.
+    *   `ctrl->CoarsenTmr`: (Commented out in `PrintTimingInfo` but present in `InitTimers`) Overall coarsening time.
+    *   `ctrl->RefTmr`: (Commented out in `PrintTimingInfo` but present in `InitTimers`) Overall refinement time.
+    *   `ctrl->SetupTmr`: Time for communication setup.
+    *   `ctrl->ProjectTmr`: Time for partition projection.
+    *   `ctrl->KWayInitTmr`: Time for k-way refinement initialization.
+    *   `ctrl->KWayTmr`: Time for k-way refinement.
+    *   `ctrl->MoveTmr`: Time for moving graph data.
+    *   `ctrl->RemapTmr`: Time for remapping partitions.
+    *   `ctrl->SerialTmr`: Time for serial operations.
+    *   `ctrl->AuxTmr1` to `ctrl->AuxTmr6`: Auxiliary timers for custom profiling.
+*   **`timer` (typedef for `double`)**: The data type used to store timer values.
+
+## Usage Examples
+
+```c
+// How timers are typically used within ParMETIS code (using macros from macros.h):
+
+// At the beginning of an operation (e.g., in SetupCtrl or a major function):
+// InitTimers(ctrl);
+
+// Around a specific code section to be timed:
+// STARTTIMER(ctrl, ctrl->MatchTmr);
+// // ... matching code ...
+// STOPTIMER(ctrl, ctrl->MatchTmr);
+
+// At the end of the main ParMETIS API function, if DBG_TIME is enabled:
+// IFSET(ctrl->dbglvl, DBG_TIME, PrintTimingInfo(ctrl));
+```
+The timer functions themselves (`cleartimer`, `starttimer`, `stoptimer`, `gettimer`) are usually accessed via macros defined in `macros.h`.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t` definition, `timer` typedef, `idx_t`, `real_t` types, and MPI wrappers (`gkMPI_Reduce`, `gkMPI_Barrier`).
+    *   `macros.h`: Defines the `cleartimer`, `starttimer`, `stoptimer`, `gettimer`, `STARTTIMER`, `STOPTIMER` macros which directly manipulate the timer values.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`:
+        *   `MPI_Wtime()`: Used by the timer macros (via `starttimer`/`stoptimer`) to get wall-clock time.
+        *   `gkMPI_Reduce`: Used in `PrintTimer` to compute sum and max of times across processors.
+        *   `gkMPI_Barrier`: Used in `STARTTIMER`/`STOPTIMER` macros (if `DBG_TIME` is set) to synchronize before/after timing.
+*   **Other Interactions**:
+    *   Timer values are cumulative. `starttimer` subtracts current time, `stoptimer` adds current time.
+    *   The output from `PrintTimingInfo` (via `PrintTimer`) is only produced on PE 0.
+    *   The "Balance" metric printed indicates how well the workload for that timed section was distributed. A balance of 1.0 is perfect; higher values indicate imbalance.
+
+```

--- a/documentation/util.c.md
+++ b/documentation/util.c.md
@@ -1,0 +1,86 @@
+# libparmetis/util.c
+
+## Overview
+
+This file provides a collection of general-purpose utility functions used throughout the ParMETIS library. These include custom printing functions, a binary search implementation, random permutation generators, mathematical helper functions (like `ispow2`, `log2Int`), array utility functions (argmax, average), and specialized balance checking routines for partitioning.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`myprintf(ctrl_t *ctrl, char *f_str, ...)`**:
+    *   Prints a formatted string to `stdout`, prepended with the MPI rank of the calling processor (`[mype]`).
+    *   Ensures a newline is printed and flushes `stdout`.
+*   **`rprintf(ctrl_t *ctrl, char *f_str, ...)`**:
+    *   Prints a formatted string to `stdout` only from PE 0.
+    *   Includes an `MPI_Barrier` after printing to synchronize output or ensure all PEs have passed that point.
+*   **`BSearch(idx_t n, idx_t *array, idx_t key)`**:
+    *   Performs a binary search for `key` in a sorted `array` of size `n`.
+    *   Returns the index of `key` if found, otherwise calls `errexit`.
+    *   It has a small optimization: for the last 8 elements, it switches to a linear scan.
+*   **`RandomPermute(idx_t n, idx_t *p, idx_t flag)`**:
+    *   Randomly permutes the array `p` of size `n`.
+    *   If `flag == 1`, initializes `p` to `0, 1, ..., n-1` before permuting.
+    *   Uses `RandomInRange` and swaps elements multiple times (number of swaps is `n`).
+*   **`FastRandomPermute(idx_t n, idx_t *p, idx_t flag)`**:
+    *   A potentially faster version of `RandomPermute` for `n >= 25`.
+    *   If `n < 25`, calls `RandomPermute`.
+    *   Otherwise, permutes elements in chunks of 4 in each iteration.
+*   **`ispow2(idx_t a)`**:
+    *   Returns 1 if `a` is a power of 2, 0 otherwise.
+*   **`log2Int(idx_t a)`**:
+    *   Returns floor(log2(`a`)).
+*   **`rargmax_strd(size_t n, real_t *x, size_t incx)`**:
+    *   Returns the index of the maximum element in a `real_t` array `x` with stride `incx`.
+*   **`rargmin_strd(size_t n, real_t *x, size_t incx)`**:
+    *   Returns the index of the minimum element in a `real_t` array `x` with stride `incx`.
+*   **`rargmax2(size_t n, real_t *x)`**:
+    *   Returns the index of the second largest element in a `real_t` array `x`.
+*   **`ravg(size_t n, real_t *x)`**:
+    *   Computes the average of elements in a `real_t` array `x`.
+*   **`rfavg(size_t n, real_t *x)`**:
+    *   Computes the average of the absolute values of elements in a `real_t` array `x`.
+*   **`BetterVBalance(idx_t ncon, real_t *vwgt, real_t *u1wgt, real_t *u2wgt)`**:
+    *   Checks if collapsing vertex `v` (with weights `vwgt`) with vertex `u2` (weights `u2wgt`) results in a better "vector balance" for the combined vertex than collapsing `v` with `u1` (weights `u1wgt`).
+    *   "Better balance" here means a smaller sum of absolute differences from the mean of combined component weights. Returns `diff1 - diff2`.
+*   **`IsHBalanceBetterFT(idx_t ncon, real_t *pfrom, real_t *pto, real_t *nvwgt, real_t *ubvec)`**:
+    *   Checks if moving a vertex with weights `nvwgt` from partition `pfrom` to partition `pto` improves overall balance.
+    *   Compares the two largest scaled imbalances (`max_weight_component / ub_for_component`) before and after the hypothetical move. If the new primary imbalance is smaller, or if primary is same and secondary is smaller, or if both are same and sum of imbalances is smaller, returns 1.
+*   **`IsHBalanceBetterTT(idx_t ncon, real_t *pt1, real_t *pt2, real_t *nvwgt, real_t *ubvec)`**:
+    *   Compares two potential target partitions, `pt1` and `pt2`, for a vertex with weights `nvwgt`.
+    *   Returns 1 if moving to `pt2` would result in a better balance state than moving to `pt1`. Similar comparison logic to `IsHBalanceBetterFT`.
+*   **`GetThreeMax(idx_t n, real_t *x, idx_t *first, idx_t *second, idx_t *third)`**:
+    *   Finds the indices of the three largest elements in a `real_t` array `x`. Stores them in `*first`, `*second`, `*third`.
+
+## Important Variables/Constants
+
+No global variables are defined in this file. Constants are typically from included headers like `defs.h`.
+
+## Usage Examples
+
+```c
+// myprintf(ctrl, "Debug message: value is %"PRIDX"\n", my_value);
+//
+// idx_t perm[100];
+// RandomPermute(100, perm, 1); // Initialize and shuffle perm
+//
+// if (ispow2(npes)) { /* ... */ }
+//
+// real_t weights[3] = {0.2, 0.5, 0.3};
+// idx_t max_idx = rargmax_strd(3, weights, 1);
+```
+These functions are called internally by many different ParMETIS modules for diverse purposes like debugging output, randomization, index searching, and balance heuristic checks.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `idx_t`, `real_t` types, `errexit`, `RandomInRange` (from GKlib), `gk_SWAP` (from GKlib), `gkMPI_Barrier`.
+    *   The balance checking functions (`BetterVBalance`, `IsHBalanceBetterFT`, `IsHBalanceBetterTT`) are crucial for refinement algorithms.
+*   **External Libraries**:
+    *   Standard C library: `stdio.h` (for `fprintf`, `vfprintf`, `fflush`), `string.h` (for `strlen`), `stdarg.h` (for variadic functions), `math.h` (for `fabs`).
+    *   `MPI (Message Passing Interface)`: `gkMPI_Barrier` is used in `rprintf`.
+*   **Other Interactions**:
+    *   `myprintf` and `rprintf` are the standard ways of producing formatted output in ParMETIS, with control over which PEs print.
+    *   The random permutation functions are essential for introducing randomness in various algorithms (e.g., initial partitioning, refinement).
+
+```

--- a/documentation/wave.c.md
+++ b/documentation/wave.c.md
@@ -1,0 +1,78 @@
+# libparmetis/wave.c
+
+## Overview
+
+This file implements the `WavefrontDiffusion` function, a specialized diffusion algorithm used in ParMETIS, particularly for initial load balancing when the number of constraints is one (`ncon=1`). The method models the flow of workload (vertices) from overloaded partitions to underloaded ones. It iteratively solves a diffusion equation on the partition connectivity graph and then moves a fraction of vertices based on the computed "flow" or "potentials."
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`WavefrontDiffusion(ctrl_t *ctrl, graph_t *graph, idx_t *home)`**:
+    *   Performs k-way directed diffusion for single-constraint load balancing.
+    *   **Parameters**:
+        *   `ctrl`: Control structure.
+        *   `graph`: The graph data, including `graph->where` (current partition) and `graph->nvwgt` (normalized vertex weights).
+        *   `home`: Array indicating the original home partition/processor of each vertex.
+    *   **Functionality**:
+        1.  **Initialization**:
+            *   Allocates memory for partition connectivity matrix (`matrix`), flow vectors (`transfer`), load imbalance (`load`), solution potentials (`solution`), etc.
+            *   Ensures all partitions initially have at least one vertex by moving vertices from the most populated partition if necessary.
+            *   Computes initial external degrees (`ed`) of vertices and initial partition weights (`npwgts`).
+            *   Calculates initial load imbalance (`ComputeLoad`).
+        2.  **Diffusion Passes (`npasses`, limited by `NGD_PASSES` or `nparts/2`)**:
+            *   In each pass `l`:
+                *   Sets up the partition connectivity graph (`matrix`) using `SetUpConnectGraph`.
+                *   Checks for disconnected subdomains in the partition graph. If connected:
+                    *   Solves the diffusion equation `Ax = b` (where `A` is `matrix`, `b` is `load`) using `ConjGrad2` to get `solution` potentials.
+                    *   Computes `transfer` amounts between partitions based on `solution` potentials using `ComputeTransferVector`.
+                *   **Vertex Movement**:
+                    *   Identifies the top three most overloaded partitions (`first`, `second`, `third`).
+                    *   Permutes vertices (`perm`), prioritizing "dirty" vertices (not in their `home` partition) in some passes.
+                    *   Iterates through a fraction of vertices (e.g., `nvtxs/3`), prioritizing those with high external degree (`ed`).
+                    *   For a selected vertex `i` in partition `from`:
+                        *   If `from` is one of the overloaded partitions (or vertex `i` is not in its `home`), it's considered for a move.
+                        *   It checks its neighbors: if a neighbor `adjncy[j]` is in partition `to`, and the `transfer` from `from` to `to` is significant (e.g., `> flowFactor * nvwgt[i]`), the vertex `i` is moved to `to`.
+                        *   Updates `psize` (local count of vertices per partition), `npwgts`, `load`, `where[i]`, and external degrees (`ed`) of `i` and its affected neighbors.
+                *   Checks for convergence: if load balance (`balance`) is good enough (`< ubfactor + 0.035`) or no swaps occurred in a pass, the diffusion may terminate early.
+        3.  **Finalization**:
+            *   Computes the final edge cut (`ComputeSerialEdgeCut`) and total vertices moved from home (`Mc_ComputeSerialTotalV`).
+            *   Calculates a final `cost` based on cut and total moved volume.
+    *   Returns the computed `cost`.
+
+## Important Variables/Constants
+
+*   **`matrix_t matrix`**: Represents the graph of connections between partitions.
+*   **`load`**: Vector storing current load imbalance for each partition.
+*   **`solution`**: Vector storing "potentials" or "pressures" from the CG solver.
+*   **`transfer`**: Vector storing computed flow amounts along edges of the partition graph.
+*   **`ed`**: Array storing the external degree of each vertex.
+*   **`psize`**: Array storing the number of vertices in each partition locally.
+*   **`flowFactor`**: A factor (0.35 to 1.0, can depend on `mype` in some versions) determining the threshold for moving a vertex based on `transfer` and its weight.
+*   **`NGD_PASSES`**: Constant from `defs.h`, upper limit on diffusion passes.
+*   `ubfactor`: Target unbalance factor from `ctrl->ubvec[0]`.
+
+## Usage Examples
+
+```
+N/A
+```
+This is an internal ParMETIS function. `WavefrontDiffusion` is typically called by `Balance_Partition` (in `initbalance.c`) as one of the strategies to achieve an initial balanced partition, especially when `ncon == 1`.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants.
+    *   `diffutil.c`: Uses `SetUpConnectGraph`, `ComputeLoad`, `ConjGrad2`, `ComputeTransferVector`, `Mc_ComputeSerialTotalV`.
+    *   `serial.c`: Uses `ComputeSerialEdgeCut`.
+    *   `util.c`: Uses `FastRandomPermute`, `RandomPermute`, `GetThreeMax`, `iargmax`.
+    *   GKlib utilities: For memory allocation, array operations.
+*   **External Libraries**:
+    *   None directly, but underlying functions use MPI.
+*   **Other Interactions**:
+    *   Modifies `graph->where` to achieve better load balance.
+    *   The `flowFactor` and number of passes (`npasses`, `NGD_PASSES`) control the aggressiveness and extent of diffusion.
+    *   The function assumes a single constraint (`ncon=1`).
+    *   The permutation of vertices (especially prioritizing dirty ones) tries to improve stability or convergence.
+
+```

--- a/documentation/weird.c.md
+++ b/documentation/weird.c.md
@@ -1,0 +1,83 @@
+# libparmetis/weird.c
+
+## Overview
+
+This file contains input validation functions for various ParMETIS V3 API routines. These functions check for `NULL` pointers for mandatory arguments and verify that critical parameters (like `ncon`, `nparts`, `ndims`, `ubvec` values, `tpwgts` sums) are within valid and reasonable ranges. If an error is detected, they print an error message and return 0 (failure), otherwise 1 (success). It also contains `PartitionSmallGraph` which is a utility for handling graphs deemed too small for parallel processing.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **Input Checking Macros**:
+    *   `RIFN(x)`: "Return If Null". Checks if pointer `x` is `NULL`. If so, prints an error and returns 0.
+    *   `RIFNP(x)`: "Return If Not Positive". Checks if the value pointed to by `x` is `<= 0`. If so, prints an error and returns 0.
+
+*   **Input Validation Functions**:
+    *   **`CheckInputsPartKway(...)`**: Validates inputs for `ParMETIS_V3_PartKway` and `ParMETIS_V3_RefineKway`.
+        *   Checks `vtxdist`, `xadj`, `adjncy`, `wgtflag`, `numflag`, `ncon`, `nparts`, `tpwgts`, `ubvec`, `options`, `edgecut`, `part`.
+        *   If weights are indicated by `wgtflag`, checks `vwgt` and `adjwgt`.
+        *   Ensures sum of `vwgt` for any constraint is not zero.
+        *   Ensures local `nvtxs > 0`.
+        *   Ensures `*ncon > 0`, `*nparts > 0`.
+        *   Validates `tpwgts` sum to 1.0 per constraint and values are in [0, 1.001].
+        *   Validates `ubvec` values are `> 1.0`.
+    *   **`CheckInputsPartGeomKway(...)`**: Validates inputs for `ParMETIS_V3_PartGeomKway`.
+        *   Similar checks as `CheckInputsPartKway`.
+        *   Additionally checks `xyz`, `ndims`.
+        *   Ensures `*ndims > 0` and `*ndims <= 3`.
+    *   **`CheckInputsPartGeom(...)`**: Validates inputs for `ParMETIS_V3_PartGeom`.
+        *   Checks `vtxdist`, `xyz`, `ndims`, `part`.
+        *   Ensures local `nvtxs > 0`.
+        *   Ensures `*ndims > 0` and `*ndims <= 3`.
+    *   **`CheckInputsAdaptiveRepart(...)`**: Validates inputs for `ParMETIS_V3_AdaptiveRepart`.
+        *   Similar checks as `CheckInputsPartKway`.
+        *   Additionally checks `ipc2redist` to be within a valid range [0.0001, 1000000.0].
+        *   `vsize` is not explicitly checked for NULL with `RIFN` but is implicitly used if weights are present.
+    *   **`CheckInputsNodeND(...)`**: Validates inputs for `ParMETIS_V3_NodeND`.
+        *   Checks `vtxdist`, `xadj`, `adjncy`, `numflag`, `options`, `order`, `sizes`.
+        *   Ensures local `nvtxs > 0`.
+    *   **`CheckInputsPartMeshKway(...)`**: Validates inputs for `ParMETIS_V3_PartMeshKway`.
+        *   Checks `elmdist`, `eptr`, `eind`, `wgtflag`, `numflag`, `ncon`, `nparts`, `tpwgts`, `ubvec`, `options`, `edgecut`, `part`.
+        *   If element weights are indicated, checks `elmwgt`.
+        *   Ensures local `nelms > 0`.
+        *   Ensures `*ncon > 0`, `*nparts > 0`.
+        *   Validates `tpwgts` and `ubvec` like other functions.
+
+*   **Utility Function**:
+    *   **`PartitionSmallGraph(ctrl_t *ctrl, graph_t *graph)`**:
+        *   Handles partitioning of graphs deemed too small for parallel processing.
+        *   It assembles the entire graph onto PE 0 using `AssembleAdaptiveGraph`.
+        *   PE 0 then calls serial METIS (`METIS_PartGraphKway`) to partition the assembled graph.
+        *   The best partition among those computed by PEs (if multiple PEs ran this, though typically it implies full assembly on PE0 which then broadcasts/scatters) is selected using `MPI_MINLOC` on the cut size.
+        *   The resulting partition is scattered back to all processors.
+        *   Finally, global partition weights (`gnpwgts`) are computed.
+
+## Important Variables/Constants
+
+The functions primarily operate on the parameters passed to them, which correspond to the ParMETIS API arguments.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions.
+*   The `CheckInputs*` functions are called at the beginning of their respective ParMETIS API routines to ensure the user has provided valid parameters. If validation fails, the API function typically returns `METIS_ERROR` after `GlobalSEMinComm` confirms an error on at least one PE.
+*   `PartitionSmallGraph` is called by routines like `ParMETIS_V3_PartKway` if the graph size is below a certain threshold (e.g., `SMALLGRAPH`).
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `graph_t` definitions, `idx_t`, `real_t` types, MPI wrappers (`gkMPI_Comm_rank`, `GlobalSESumComm`), and GKlib utilities (`isum`, `rsum`).
+    *   `initbalance.c`: `AssembleAdaptiveGraph` is used by `PartitionSmallGraph`.
+    *   `graph.c`: `FreeGraph` is used by `PartitionSmallGraph`.
+    *   `metis.h` (external METIS library): `METIS_SetDefaultOptions`, `METIS_PartGraphKway` are used by `PartitionSmallGraph`.
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used for communication in `PartitionSmallGraph` and by `GlobalSEMinComm`/`GlobalSESumComm` in the check functions.
+    *   `METIS`: Serial METIS is used by `PartitionSmallGraph`.
+    *   Standard C library: `stdio.h` (for `printf`), `stdlib.h` (for `abort`).
+*   **Other Interactions**:
+    *   The input check functions are the first line of defense against user error for API calls.
+    *   `PartitionSmallGraph` provides a fallback to serial METIS for small graphs, avoiding the overhead and complexity of parallel algorithms where they might not be beneficial.
+
+```

--- a/documentation/wspace.c.md
+++ b/documentation/wspace.c.md
@@ -1,0 +1,82 @@
+# libparmetis/wspace.c
+
+## Overview
+
+This file manages workspace memory allocation and a specialized memory pool for `cnbr_t` structures (coarse neighbor information used in refinement) within ParMETIS. It utilizes GKlib's `mcore` functionality for efficient, stack-like workspace allocation, allowing for large temporary arrays to be allocated and freed in blocks. The `cnbr_t` pool is a dynamically growing array to store neighbor information during graph refinement.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`AllocateWSpace(ctrl_t *ctrl, size_t nwords)`**:
+    *   Initializes the main workspace for ParMETIS.
+    *   Creates a GKlib memory core (`ctrl->mcore`) of size `nwords * sizeof(idx_t)`. This core is used for most temporary allocations via `wspacemalloc` and its typed variants.
+*   **`AllocateRefinementWorkSpace(ctrl_t *ctrl, idx_t nbrpoolsize)`**:
+    *   Allocates and initializes a specialized memory pool (`ctrl->cnbrpool`) for storing `cnbr_t` structures. These structures hold information about neighboring partitions during refinement.
+    *   `ctrl->nbrpoolsize`: Initial size of the pool.
+    *   `ctrl->nbrpoolcpos`: Current position (next free entry).
+    *   `ctrl->nbrpoolreallocs`: Counter for reallocations.
+*   **`FreeWSpace(ctrl_t *ctrl)`**:
+    *   Deallocates the main workspace memory core (`ctrl->mcore`).
+    *   Prints statistics about the `cnbrpool` usage (size, current position, reallocations) if `DBG_INFO` is enabled.
+    *   Frees the `ctrl->cnbrpool`.
+*   **`wspacemalloc(ctrl_t *ctrl, size_t nbytes)`**:
+    *   Allocates `nbytes` of memory from the GKlib memory core (`ctrl->mcore`). This is a stack-like allocation.
+*   **`iwspacemalloc(ctrl_t *ctrl, size_t n)`**:
+    *   Typed wrapper for `wspacemalloc`, allocating space for `n` `idx_t` elements.
+*   **`rwspacemalloc(ctrl_t *ctrl, size_t n)`**:
+    *   Typed wrapper for `wspacemalloc`, allocating space for `n` `real_t` elements.
+*   **`ikvwspacemalloc(ctrl_t *ctrl, size_t n)`**:
+    *   Typed wrapper for `wspacemalloc`, allocating space for `n` `ikv_t` elements.
+*   **`rkvwspacemalloc(ctrl_t *ctrl, size_t n)`**:
+    *   Typed wrapper for `wspacemalloc`, allocating space for `n` `rkv_t` elements.
+*   **`cnbrpoolReset(ctrl_t *ctrl)`**:
+    *   Resets the current position pointer (`ctrl->nbrpoolcpos`) of the `cnbrpool` to 0, effectively clearing the pool for reuse without deallocating memory.
+*   **`cnbrpoolGetNext(ctrl_t *ctrl, idx_t nnbrs)`**:
+    *   Gets a block of `nnbrs` `cnbr_t` entries from the `cnbrpool`.
+    *   `nnbrs` is capped by `ctrl->nparts`.
+    *   If the pool is too small, it reallocates `ctrl->cnbrpool` (increasing its size by `max(10*nnbrs, current_size/2)`).
+    *   Returns the starting index of the allocated block in the pool.
+
+## Important Variables/Constants
+
+*   **`ctrl->mcore` (gk_mcore_t *)**: Pointer to the GKlib memory core used for general workspace allocations.
+*   **`ctrl->nbrpoolsize` (size_t)**: Current allocated size (number of `cnbr_t` elements) of the neighbor pool.
+*   **`ctrl->nbrpoolcpos` (size_t)**: Index of the next available free entry in `cnbrpool`.
+*   **`ctrl->nbrpoolreallocs` (size_t)**: Number of times `cnbrpool` has been reallocated.
+*   **`ctrl->cnbrpool` (cnbr_t *)**: The actual memory pool for storing `cnbr_t` structures.
+
+## Usage Examples
+
+```c
+// General workspace allocation:
+// WCOREPUSH; // Start a new scope (macro from macros.h)
+// idx_t *my_temp_array = iwspacemalloc(ctrl, 1000);
+// real_t *another_temp = rwspacemalloc(ctrl, 500);
+// // ... use arrays ...
+// WCOREPOP; // Frees my_temp_array and another_temp (and anything else allocated via wspacemalloc in this scope)
+
+// Coarse neighbor pool usage (typically in refinement functions):
+// // At the start of a refinement phase:
+// cnbrpoolReset(ctrl);
+//
+// // When processing a vertex 'v' needing 'num_neighbors' entries:
+// idx_t ckr_inbr = cnbrpoolGetNext(ctrl, num_neighbors);
+// cnbr_t *mynbrs = ctrl->cnbrpool + ckr_inbr;
+// // ... populate mynbrs[0]...mynbrs[num_neighbors-1] ...
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Provides `ctrl_t`, `cnbr_t`, `ikv_t`, `rkv_t`, `idx_t`, `real_t` types, and GKlib types/functions (`gk_mcore_t`, `gk_mcoreCreate`, `gk_mcoreDestroy`, `gk_mcoreMalloc`, `gk_malloc`, `gk_realloc`, `gk_free`, `gk_min`, `gk_max`).
+    *   `DBG_INFO` (from `defs.h` via `parmetislib.h`): Controls printing of `cnbrpool` statistics.
+*   **External Libraries**:
+    *   GKlib (embedded): The memory core (`mcore`) functionality and standard memory allocation wrappers (`gk_malloc`, etc.) are from GKlib.
+*   **Other Interactions**:
+    *   `AllocateWSpace` is typically called once at the beginning of a ParMETIS API function to set up the main temporary memory region.
+    *   `AllocateRefinementWorkSpace` is called before refinement phases that require `ckrinfo_t` and `cnbr_t` structures (e.g., `ComputePartitionParams`, `KWayFM`).
+    *   `wspacemalloc` and its typed variants are used throughout ParMETIS for allocating temporary arrays needed within a specific scope, often bracketed by `WCOREPUSH` and `WCOREPOP` (macros from `macros.h`) for automatic cleanup.
+    *   The `cnbrpool` provides a dynamic array for storing adjacency information with respect to partitions, which is heavily used during k-way refinement.
+
+```

--- a/documentation/xyzpart.c.md
+++ b/documentation/xyzpart.c.md
@@ -1,0 +1,99 @@
+# libparmetis/xyzpart.c
+
+## Overview
+
+This file implements coordinate-based partitioning methods for ParMETIS. These methods use the geometric coordinates of vertices to partition the graph, often as an initial step before graph-based partitioning or refinement. The main idea is to sort vertices based on their coordinates (or derived values like Z-ordering or Hilbert curve ordering implicitly) and then divide the sorted list into `npes` (number of processors) contiguous blocks.
+
+## Key Components
+
+### Functions/Classes/Modules
+
+*   **`Coordinate_Partition(ctrl_t *ctrl, graph_t *graph, idx_t ndims, real_t *xyz, idx_t setup)`**:
+    *   The main function for coordinate-based partitioning.
+    *   **Parameters**:
+        *   `ctrl`: Control structure.
+        *   `graph`: Graph structure (used for `vtxdist`, `nvtxs`, and to store the resulting partition in `graph->where`).
+        *   `ndims`: Number of dimensions of the coordinates.
+        *   `xyz`: Array of vertex coordinates (size `graph->nvtxs * ndims`).
+        *   `setup`: Flag, if true, calls `CommSetup` (usually true for `PartGeomKway`, false for `PartGeom`).
+    *   **Functionality**:
+        1.  If `setup` is true, calls `CommSetup` to prepare graph communication structures.
+        2.  Allocates `bxyz` to store binned coordinates and `cand (ikv_t *)` to store sort keys.
+        3.  Calls `IRBinCoordinates` to discretize floating-point coordinates into integer bins.
+        4.  **Z-ordering**: Computes a Z-order curve value (Morton code) for each vertex based on its binned coordinates (`bxyz`). This value interleaves the bits of the coordinates in different dimensions to create a 1D key that preserves spatial locality. The Z-order key is stored in `cand[i].key`, and the global vertex index in `cand[i].val`.
+        5.  Calls `PseudoSampleSort` (a parallel sort variant) to sort the `cand` array based on the Z-order keys. This effectively sorts all global vertices by their Z-order.
+        6.  The sorted list implicitly defines the partition: the first `gnvtxs/npes` vertices go to PE 0, the next to PE 1, and so on. `PseudoSampleSort` directly computes `graph->where` based on this sorted distribution.
+*   **`IRBinCoordinates(ctrl_t *ctrl, graph_t *graph, idx_t ndims, real_t *xyz, idx_t nbins, idx_t *bxyz)`**:
+    *   "Iterative Refinement Binning" of coordinates. Converts floating-point `xyz` coordinates into integer bin indices (`bxyz`) for each dimension.
+    *   For each dimension `k`:
+        1.  Sorts local vertices based on their coordinate in dimension `k`.
+        2.  Determines global min/max coordinates in this dimension.
+        3.  Initializes `nbins` `emarkers` (bin boundaries) uniformly spanning the global range.
+        4.  Iteratively refines these bin boundaries for up to 5 iterations:
+            *   Counts vertices in each bin globally (`gcounts`).
+            *   If imbalance is high (e.g., `max(gcounts) > 4*gnvtxs/nbins`), adjusts `emarkers` to better distribute vertices, aiming for roughly `gnvtxs/nbins` per bin. This involves finding new split points within overpopulated bins.
+        5.  Assigns each local vertex its bin number for dimension `k` based on the final `emarkers`.
+*   **`RBBinCoordinates(ctrl_t *ctrl, graph_t *graph, idx_t ndims, real_t *xyz, idx_t nbins, idx_t *bxyz)`**:
+    *   "Recursive Bisection Binning" of coordinates. Another method to discretize coordinates.
+    *   For each dimension `k`:
+        1.  Initializes 2 bins using the global center of mass as the separator.
+        2.  Iteratively splits the most populated bins (based on `gcounts`) by their center of mass until `nbins` are created.
+        3.  Assigns bin numbers to local vertices.
+    *   *(Note: This function appears to be an alternative to `IRBinCoordinates` but `IRBinCoordinates` is called by `Coordinate_Partition`.)*
+*   **`SampleSort(ctrl_t *ctrl, graph_t *graph, ikv_t *elmnts)`**:
+    *   A parallel sample sort algorithm to sort `elmnts (ikv_t *)` distributed across processors.
+    *   Each PE selects local splitters. These are gathered, globally sorted, and global splitters are chosen.
+    *   Elements are then sent to PEs based on these global splitters (`MPI_Alltoall`).
+    *   Each PE sorts its received elements.
+    *   A final step determines the global rank and assigns partition numbers (`elmnts[i].key = target_pe`).
+    *   The sorted `elmnts` (with new keys as target PEs and values as original global vertex IDs) are sent back to original PEs.
+    *   `graph->where` is populated from the received sorted elements.
+    *   *(Note: Assumes `nvtxs > npes` on each PE. Described as "poorly implemented" with a TODO to fix in 4.0. `PseudoSampleSort` is used instead by `Coordinate_Partition`.)*
+*   **`PseudoSampleSort(ctrl_t *ctrl, graph_t *graph, ikv_t *elmnts)`**:
+    *   A variant of parallel sample sort, likely optimized or simplified compared to `SampleSort`. This is the one actually used by `Coordinate_Partition`.
+    *   **Steps**:
+        1.  Selects local samples (`mypicks`) from locally sorted `elmnts`. The number of local samples `nlsamples` is determined heuristicall (e.g., `gnvtxs/(npes*npes)` capped by `npes` and a minimum).
+        2.  Gathers all samples (`allpicks`) to all PEs.
+        3.  Sorts `allpicks` globally and selects `npes-1` global splitters, stored back in `mypicks`.
+        4.  Each PE determines how many of its local `elmnts` fall into buckets defined by global splitters (`scounts`).
+        5.  `MPI_Alltoall` communicates these counts (`rcounts`).
+        6.  `MPI_Alltoallv` redistributes `elmnts` based on these counts. Received elements are in `relmnts`.
+        7.  `relmnts` are sorted locally.
+        8.  A global prefix sum (`MPI_Scan`) on `nrecv` (number of elements received by each PE) determines the global rank range for each PE's elements.
+        9.  Each PE assigns a target PE index (`relmnts[j].key = target_pe`) to its `relmnts` based on `vtxdist` (global vertex distribution for final partitions) and the global rank.
+        10. `MPI_Alltoallv` sends `relmnts` back to the PEs that originally owned the vertex data (using original `scounts`/`rcounts`).
+        11. `graph->where` is populated from the final received `elmnts`.
+
+## Important Variables/Constants
+
+*   **`xyz`**: Input array of vertex coordinates.
+*   **`ndims`**: Number of dimensions for coordinates.
+*   **`bxyz`**: Temporary array storing integer bin indices for each vertex and dimension.
+*   **`cand (ikv_t *)`**: Array storing Z-order keys (`key`) and global vertex indices (`val`) for sorting.
+*   **`nbins` (in `IRBinCoordinates`)**: Number of bins to discretize coordinates into (e.g., `1<<9 = 512`).
+*   **`emarkers` (in `IRBinCoordinates`)**: Array of bin boundaries.
+*   **`mypicks`, `allpicks` (in sorting functions)**: Arrays to store local and global samples/splitters.
+*   **`elmnts` (in sorting functions)**: The array of `ikv_t` (key/value pairs) being sorted. Key is sort criteria, value is original global ID. After sorting and partitioning, key becomes target PE.
+*   **`graph->where`**: Output array where the partition assignment (target PE) for each local vertex is stored.
+
+## Usage Examples
+
+```
+N/A
+```
+These are internal ParMETIS functions. `Coordinate_Partition` is the main routine called by higher-level functions like `ParMETIS_V3_PartGeomKway` (in `gkmetis.c`) or `ParMETIS_V3_PartGeom`.
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies**:
+    *   `parmetislib.h`: Core definitions, types, constants, MPI wrappers, memory utilities.
+    *   `comm.c`: `CommSetup`, `CommUpdateNnbrs` (used by `SampleSort`).
+    *   GKlib utilities: Sorting (`ikvsorti`, `ikvsortii`, `rkvsorti`), memory allocation, math (`gk_min`).
+*   **External Libraries**:
+    *   `MPI (Message Passing Interface)`: Used extensively in `IRBinCoordinates` and the sorting routines for `MPI_Allreduce`, `MPI_Allgather`, `MPI_Alltoall`, `MPI_Alltoallv`, `MPI_Scan`.
+*   **Other Interactions**:
+    *   The quality of the coordinate-based partition depends heavily on the spatial distribution of vertices and the effectiveness of the Z-ordering and parallel sorting in preserving locality.
+    *   `PseudoSampleSort` is a complex parallel sorting algorithm critical to this partitioning method.
+    *   These routines are often used to provide a good initial data distribution for more computationally intensive graph-based partitioning algorithms.
+
+```


### PR DESCRIPTION
This commit introduces a new `documentation` directory populated with Markdown files for each significant source code file (`.c` and `.h`) in the `libparmetis` and `programs` directories.

Each Markdown file includes:
- An overview of the file's purpose and role.
- A list of key components (functions, structs, macros, etc.) with descriptions.
- Descriptions of important variables and constants.
- Usage examples (where applicable, otherwise "N/A").
- Notes on internal and external dependencies and interactions.

This documentation is intended to help you understand, maintain, and extend the ParMETIS codebase. Files in `libparmetis` and `programs` were targeted. For files with identical names in these two directories (e.g. `io.c`, `proto.h`), the ones in `programs` have been prefixed with `programs_` in their markdown filename (e.g. `programs_io.c.md`) to avoid collisions in the `documentation` directory.